### PR TITLE
Add const validation keyword

### DIFF
--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -16,22 +16,26 @@ module RubyLLM
           }.compact
         end
 
-        def number_schema(description: nil, minimum: nil, maximum: nil, multiple_of: nil)
+        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
           {
             type: "number",
             description: description,
             minimum: minimum,
             maximum: maximum,
+            exclusiveMinimum: greater_than,
+            exclusiveMaximum: less_than,
             multipleOf: multiple_of
           }.compact
         end
 
-        def integer_schema(description: nil, minimum: nil, maximum: nil, multiple_of: nil)
+        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
           {
             type: "integer",
             description: description,
             minimum: minimum,
             maximum: maximum,
+            exclusiveMinimum: greater_than,
+            exclusiveMaximum: less_than,
             multipleOf: multiple_of
           }.compact
         end

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -4,8 +4,14 @@ module RubyLLM
   class Schema
     module DSL
       module SchemaBuilders
-        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, format: nil)
-          {
+        NOT_GIVEN = Object.new.freeze
+
+        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options)
+          format = options.delete(:format)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("string", options)
+
+          add_const({
             type: "string",
             enum: enum,
             description: description,
@@ -13,11 +19,15 @@ module RubyLLM
             maxLength: max_length,
             pattern: pattern,
             format: format
-          }.compact
+          }.compact, const)
         end
 
-        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
-          {
+        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
+          multiple_of = options.delete(:multiple_of)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("number", options)
+
+          add_const({
             type: "number",
             description: description,
             minimum: minimum,
@@ -25,11 +35,15 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of
-          }.compact
+          }.compact, const)
         end
 
-        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
-          {
+        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
+          multiple_of = options.delete(:multiple_of)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("integer", options)
+
+          add_const({
             type: "integer",
             description: description,
             minimum: minimum,
@@ -37,15 +51,15 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of
-          }.compact
+          }.compact, const)
         end
 
-        def boolean_schema(description: nil)
-          {type: "boolean", description: description}.compact
+        def boolean_schema(description: nil, const: NOT_GIVEN)
+          add_const({type: "boolean", description: description}.compact, const)
         end
 
-        def null_schema(description: nil)
-          {type: "null", description: description}.compact
+        def null_schema(description: nil, const: NOT_GIVEN)
+          add_const({type: "null", description: description}.compact, const)
         end
 
         def object_schema(description: nil, of: nil, reference: nil, &block)
@@ -112,6 +126,17 @@ module RubyLLM
         end
 
         private
+
+        def add_const(schema, const)
+          schema[:const] = const unless const.equal?(NOT_GIVEN)
+          schema
+        end
+
+        def raise_unknown_options!(type, options)
+          return if options.empty?
+
+          raise ArgumentError, "unknown #{type} schema option: #{options.keys.first.inspect}"
+        end
 
         def determine_array_items(of, &)
           return collect_schemas_from_block(&).first if block_given?

--- a/spec/ruby_llm/schema/properties/booleans_spec.rb
+++ b/spec/ruby_llm/schema/properties/booleans_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe RubyLLM::Schema, "boolean properties" do
     properties = schema_class.properties
     expect(properties[:enabled]).to eq({type: "boolean", description: "Enabled field"})
   end
+
+  it "supports boolean const values" do
+    schema_class.boolean :enabled, const: false
+
+    properties = schema_class.properties
+    expect(properties[:enabled]).to eq({type: "boolean", const: false})
+  end
 end

--- a/spec/ruby_llm/schema/properties/null_spec.rb
+++ b/spec/ruby_llm/schema/properties/null_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe RubyLLM::Schema, "null properties" do
     properties = schema_class.properties
     expect(properties[:placeholder]).to eq({type: "null", description: "Null field"})
   end
+
+  it "supports null const values" do
+    schema_class.null :deleted_at, const: nil
+
+    properties = schema_class.properties
+    expect(properties[:deleted_at]).to eq({type: "null", const: nil})
+  end
 end

--- a/spec/ruby_llm/schema/properties/numbers_spec.rb
+++ b/spec/ruby_llm/schema/properties/numbers_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
     })
   end
 
+  it "supports number const values" do
+    schema_class.number :version, const: 1.5
+
+    properties = schema_class.properties
+    expect(properties[:version]).to eq({type: "number", const: 1.5})
+  end
+
   it "supports number type with description" do
     schema_class.number :price, description: "Price field"
 
@@ -52,5 +59,12 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
       exclusiveMinimum: 17,
       exclusiveMaximum: 66
     })
+  end
+
+  it "supports integer const values" do
+    schema_class.integer :version, const: 1
+
+    properties = schema_class.properties
+    expect(properties[:version]).to eq({type: "integer", const: 1})
   end
 end

--- a/spec/ruby_llm/schema/properties/numbers_spec.rb
+++ b/spec/ruby_llm/schema/properties/numbers_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
     })
   end
 
+  it "supports exclusive number boundaries" do
+    schema_class.number :score, greater_than: 0, less_than: 100
+
+    properties = schema_class.properties
+    expect(properties[:score]).to eq({
+      type: "number",
+      exclusiveMinimum: 0,
+      exclusiveMaximum: 100
+    })
+  end
+
   it "supports number type with description" do
     schema_class.number :price, description: "Price field"
 
@@ -30,5 +41,16 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
 
     properties = schema_class.properties
     expect(properties[:count]).to eq({type: "integer", description: "Count value"})
+  end
+
+  it "supports exclusive integer boundaries" do
+    schema_class.integer :age, greater_than: 17, less_than: 66
+
+    properties = schema_class.properties
+    expect(properties[:age]).to eq({
+      type: "integer",
+      exclusiveMinimum: 17,
+      exclusiveMaximum: 66
+    })
   end
 end

--- a/spec/ruby_llm/schema/properties/strings_spec.rb
+++ b/spec/ruby_llm/schema/properties/strings_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe RubyLLM::Schema, "string properties" do
     })
   end
 
+  it "supports string const values" do
+    schema_class.string :role, const: "admin"
+
+    properties = schema_class.properties
+    expect(properties[:role]).to eq({type: "string", const: "admin"})
+  end
+
   it "supports string type with additional options" do
     schema_class.string :email, format: "email", min_length: 5, max_length: 100, pattern: "\\S+@\\S+", description: "Email field"
 


### PR DESCRIPTION
Closes #34

## Summary
- Add `const:` support to primitive schema builders
- Preserve explicit false and nil const values
- Cover string, number, integer, boolean, and null schemas with specs

## Verification
- `bundle exec rake`