### PR TITLE
Support runtime schema values

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,27 @@ object :profile, of: :person, unevaluated_properties: false
 array :values, of: :integer, unevaluated_items: false
 ```
 
+### Runtime Values
+
+Any schema value can be a proc, resolved when the schema is rendered. That lets one schema class produce different documents per instance — useful when an enum comes from the database.
+
+```ruby
+class RoleSchema < RubyLLM::Schema
+  description -> { "Roles available to #{@account.name}" }
+
+  string :role, enum: -> { @account.roles.pluck(:name) }
+
+  def initialize(account:)
+    super()
+    @account = account
+  end
+end
+
+RoleSchema.new(account: account).to_json_schema
+```
+
+A proc with no arguments is evaluated in the instance's context, so it can read instance variables. A proc that takes one argument receives the schema instance instead.
+
 ### Boolean and Raw Schemas
 
 JSON Schema allows `true` and `false` in place of a schema object: `true` accepts every value, `false` accepts none. Inside a block, `any_schema` and `no_schema` emit them.

--- a/lib/ruby_llm/schema/json_output.rb
+++ b/lib/ruby_llm/schema/json_output.rb
@@ -22,14 +22,30 @@ module RubyLLM
 
         {
           name: @name,
-          description: @description || self.class.description,
-          schema: schema_hash
+          description: resolve_runtime_values(@description || self.class.description),
+          schema: resolve_runtime_values(schema_hash)
         }
       end
 
       def to_json(*_args)
         validate! # Validate schema before generating JSON string
         JSON.pretty_generate(to_json_schema)
+      end
+
+      private
+
+      # Values declared as procs are resolved here, so one schema class can render differently per instance
+      def resolve_runtime_values(value)
+        case value
+        when Proc
+          resolve_runtime_values(value.arity.zero? ? instance_exec(&value) : value.call(self))
+        when Hash
+          value.transform_values { |nested_value| resolve_runtime_values(nested_value) }
+        when Array
+          value.map { |nested_value| resolve_runtime_values(nested_value) }
+        else
+          value
+        end
       end
     end
   end

--- a/spec/ruby_llm/schema/robustness/runtime_values_spec.rb
+++ b/spec/ruby_llm/schema/robustness/runtime_values_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "runtime schema values" do
+  it "evaluates proc-backed values when rendering JSON schema" do
+    schema_class = Class.new(described_class) do
+      def initialize(user_names:)
+        super()
+        @user_names = user_names
+      end
+
+      string :name, enum: -> { @user_names }
+    end
+
+    first_schema = schema_class.new(user_names: %w[Alice Bob]).to_json_schema
+    second_schema = schema_class.new(user_names: %w[Carol]).to_json_schema
+
+    expect(first_schema[:schema][:properties][:name][:enum]).to eq(%w[Alice Bob])
+    expect(second_schema[:schema][:properties][:name][:enum]).to eq(%w[Carol])
+    expect(schema_class.properties[:name][:enum]).to be_a(Proc)
+  end
+
+  it "evaluates runtime values inside nested schemas" do
+    schema_class = Class.new(described_class) do
+      def initialize(user_names:)
+        super()
+        @user_names = user_names
+      end
+
+      array :users do
+        object do
+          string :name, enum: -> { @user_names }
+        end
+      end
+    end
+
+    output = schema_class.new(user_names: %w[Alice Bob]).to_json_schema
+    name_schema = output[:schema][:properties][:users][:items][:properties][:name]
+
+    expect(name_schema[:enum]).to eq(%w[Alice Bob])
+  end
+
+  it "supports procs that receive the schema instance" do
+    schema_class = Class.new(described_class) do
+      attr_reader :allowed_roles
+
+      def initialize(allowed_roles:)
+        super()
+        @allowed_roles = allowed_roles
+      end
+
+      string :role, enum: ->(schema) { schema.allowed_roles.dup }
+    end
+
+    output = schema_class.new(allowed_roles: %w[admin user]).to_json_schema
+
+    expect(output[:schema][:properties][:role][:enum]).to eq(%w[admin user])
+  end
+
+  it "resolves runtime values in the description" do
+    schema_class = Class.new(described_class) do
+      description -> { "Generated for #{@audience}" }
+
+      def initialize(audience:)
+        super()
+        @audience = audience
+      end
+    end
+
+    expect(schema_class.new(audience: "admins").to_json_schema[:description]).to eq("Generated for admins")
+  end
+
+  it "serializes resolved values to JSON" do
+    schema_class = Class.new(described_class) do
+      def initialize(user_names:)
+        super()
+        @user_names = user_names
+      end
+
+      string :name, enum: -> { @user_names }
+    end
+
+    output = JSON.parse(schema_class.new(user_names: %w[Alice Bob]).to_json)
+
+    expect(output.dig("schema", "properties", "name", "enum")).to eq(%w[Alice Bob])
+  end
+end


### PR DESCRIPTION
Closes #27

## Summary
- Resolve proc-backed schema values at render time
- Evaluate zero-arity procs in the schema instance context
- Support procs that explicitly receive the schema instance
- Cover nested runtime values and per-instance output differences

## Verification
- `bundle exec rake`