### PR TITLE
Add schema composition keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,38 @@ any_of :identifier do
 end
 ```
 
+### Composition (oneOf, allOf, not)
+
+`one_of` matches exactly one of the given schemas, `all_of` matches all of them, and `none_of` matches none of them.
+
+```ruby
+one_of :payment do
+  object do
+    string :card_number
+  end
+
+  object do
+    string :iban
+  end
+end
+
+all_of :account do
+  object do
+    string :id
+  end
+
+  object do
+    string :status
+  end
+end
+
+none_of :status do
+  string enum: ["deleted"]
+end
+```
+
+`none_of` with a single schema emits `not: { ... }`. With several, it emits `not: { anyOf: [...] }`.
+
 ### Schema Definitions and References
 
 You can define sub-schemas and reference them in other schemas, or reference the root schema to generate recursive schemas.

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -93,7 +93,7 @@ module RubyLLM
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      %i[string number integer boolean array object any_of one_of null].include?(method_name) || super
+      %i[string number integer boolean array object any_of one_of all_of none_of null].include?(method_name) || super
     end
   end
 end

--- a/lib/ruby_llm/schema/dsl/complex_types.rb
+++ b/lib/ruby_llm/schema/dsl/complex_types.rb
@@ -20,6 +20,14 @@ module RubyLLM
           add_property(name, one_of_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
+        def all_of(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, all_of_schema(description: description, **options, &block), required: required, requires: requires)
+        end
+
+        def none_of(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, none_of_schema(description: description, **options, &block), required: required, requires: requires)
+        end
+
         def optional(name, description: nil, &block)
           any_of(name, description: description) do
             instance_eval(&block)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -125,6 +125,24 @@ module RubyLLM
           }.compact
         end
 
+        def all_of_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            description: description,
+            allOf: schemas
+          }.compact
+        end
+
+        def none_of_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            description: description,
+            not: schemas.one? ? schemas.first : {anyOf: schemas}
+          }.compact
+        end
+
         private
 
         def add_const(schema, const)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -116,6 +116,24 @@ module RubyLLM
           }.compact
         end
 
+        def all_of_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            description: description,
+            allOf: schemas
+          }.compact
+        end
+
+        def none_of_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            description: description,
+            not: schemas.size == 1 ? schemas.first : {anyOf: schemas}
+          }.compact
+        end
+
         private
 
         def determine_array_items(of, &)

--- a/spec/ruby_llm/schema/properties/all_of_spec.rb
+++ b/spec/ruby_llm/schema/properties/all_of_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "allOf properties" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports all_of with mixed schemas" do
+    schema_class.all_of :payload do
+      object do
+        string :name
+      end
+
+      object do
+        integer :age
+      end
+    end
+
+    all_of_schemas = schema_class.properties[:payload][:allOf]
+
+    expect(all_of_schemas.length).to eq(2)
+    expect(all_of_schemas[0][:properties][:name]).to eq({type: "string"})
+    expect(all_of_schemas[1][:properties][:age]).to eq({type: "integer"})
+  end
+
+  it "supports arrays of allOf types" do
+    schema_class.array :items do
+      all_of :value do
+        object do
+          string :name
+        end
+
+        object do
+          integer :age
+        end
+      end
+    end
+
+    all_of_schemas = schema_class.properties[:items][:items][:allOf]
+
+    expect(all_of_schemas.length).to eq(2)
+    expect(all_of_schemas.map { |schema| schema[:type] }).to eq(%w[object object])
+  end
+end

--- a/spec/ruby_llm/schema/properties/none_of_spec.rb
+++ b/spec/ruby_llm/schema/properties/none_of_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "not properties" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports none_of with a single schema" do
+    schema_class.none_of :status do
+      string enum: ["forbidden"]
+    end
+
+    properties = schema_class.properties
+
+    expect(properties[:status]).to eq({
+      not: {type: "string", enum: ["forbidden"]}
+    })
+  end
+
+  it "wraps multiple none_of schemas in anyOf" do
+    schema_class.none_of :status do
+      string enum: ["forbidden"]
+      integer
+    end
+
+    properties = schema_class.properties
+
+    expect(properties[:status]).to eq({
+      not: {
+        anyOf: [
+          {type: "string", enum: ["forbidden"]},
+          {type: "integer"}
+        ]
+      }
+    })
+  end
+
+  it "supports arrays of not schemas" do
+    schema_class.array :items do
+      none_of :value do
+        null
+      end
+    end
+
+    item_schema = schema_class.properties[:items][:items]
+
+    expect(item_schema).to eq({not: {type: "null"}})
+  end
+end


### PR DESCRIPTION
Closes #37

## Summary
- Add `all_of` support for Draft 2020-12 `allOf`
- Add `none_of` support for JSON Schema `not`
- Wrap multiple `none_of` child schemas in `not: { anyOf: [...] }`
- Cover direct and array item composition specs

## Verification
- `bundle exec rake`