### PR TITLE
Add object validation keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,32 @@ object :settings, description: "User preferences" do
 end
 ```
 
+### Object Key Constraints
+
+Objects can constrain how many properties they carry, and what their keys look like.
+
+- `min_properties` / `max_properties`: how many properties the object may have
+- `keys`: a schema every property name must match, as JSON Schema `propertyNames`
+- `keys_matching`: a schema for the properties whose names match a pattern, as JSON Schema `patternProperties`
+
+```ruby
+object :metadata, min_properties: 1, max_properties: 10 do
+  keys do
+    string pattern: "^[a-z_]+$"
+  end
+
+  keys_matching(/^x-/) do
+    string
+  end
+
+  keys_matching(/^count_/) do
+    integer minimum: 0
+  end
+end
+```
+
+`keys` and `keys_matching` also work at the root of a schema class and inside `define`.
+
 ### Union Types (anyOf)
 
 Union types are a way to specify that a property can be one of several types.

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -63,7 +63,7 @@ module RubyLLM
           add_const({type: "null", description: description}.compact, const)
         end
 
-        def object_schema(description: nil, of: nil, reference: nil, unevaluated_properties: nil, &block)
+        def object_schema(description: nil, of: nil, reference: nil, min_properties: nil, max_properties: nil, unevaluated_properties: nil, &block)
           if reference
             warn "[DEPRECATION] The `reference` option will be deprecated. Please use `of` instead."
             of = reference
@@ -72,6 +72,8 @@ module RubyLLM
           schema = of ? determine_object_reference(of, description) : build_object_schema(description, &block)
 
           schema[:unevaluatedProperties] = unevaluated_properties unless unevaluated_properties.nil?
+          schema[:minProperties] = min_properties unless min_properties.nil?
+          schema[:maxProperties] = max_properties unless max_properties.nil?
           schema
         end
 
@@ -163,6 +165,7 @@ module RubyLLM
           }.compact
 
           merge_conditions(schema, sub_schema)
+          merge_object_keywords(schema, sub_schema)
         end
 
         def determine_object_reference(of, description = nil)
@@ -245,6 +248,7 @@ module RubyLLM
             schema[:description] = description if description
 
             merge_conditions(schema, schema_class)
+            merge_object_keywords(schema, schema_class)
           end
         end
       end

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -53,15 +53,19 @@ module RubyLLM
           {type: "null", description: description}.compact
         end
 
-        def object_schema(description: nil, of: nil, reference: nil, unevaluated_properties: nil, &block)
+        def object_schema(description: nil, of: nil, reference: nil, min_properties: nil, max_properties: nil, unevaluated_properties: nil, &block)
           if reference
             warn "[DEPRECATION] The `reference` option will be deprecated. Please use `of` instead."
             of = reference
           end
 
           schema = of ? determine_object_reference(of, description) : build_object_schema(description, &block)
-          schema[:unevaluatedProperties] = unevaluated_properties unless unevaluated_properties.nil?
-          schema
+
+          schema.merge!({
+            minProperties: min_properties,
+            maxProperties: max_properties,
+            unevaluatedProperties: unevaluated_properties
+          }.compact)
         end
 
         def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, &block)
@@ -139,7 +143,7 @@ module RubyLLM
               description: description
             }.compact
 
-            merge_conditions(schema, sub_schema)
+            merge_schema_keywords(schema, sub_schema)
           end
         end
 
@@ -219,7 +223,7 @@ module RubyLLM
 
             schema[:description] = description if description
 
-            merge_conditions(schema, schema_class)
+            merge_schema_keywords(schema, schema_class)
           end
         end
       end

--- a/lib/ruby_llm/schema/dsl/utilities.rb
+++ b/lib/ruby_llm/schema/dsl/utilities.rb
@@ -16,9 +16,23 @@ module RubyLLM
             additionalProperties: sub_schema.additional_properties
           }
 
+          merge_object_keywords(schema, sub_schema)
           merge_conditions(schema, sub_schema)
 
           definitions[name] = schema
+        end
+
+        def object_keywords
+          @object_keywords ||= {}
+        end
+
+        def keys_matching(pattern, &block)
+          object_keywords[:patternProperties] ||= {}
+          object_keywords[:patternProperties][pattern_source(pattern)] = collect_schemas_from_block(&block).first
+        end
+
+        def keys(&block)
+          object_keywords[:propertyNames] = collect_schemas_from_block(&block).first
         end
 
         def reference(schema_name)
@@ -56,6 +70,16 @@ module RubyLLM
 
         def schema_class?(type)
           (type.is_a?(Class) && type < Schema) || type.is_a?(Schema)
+        end
+
+        def merge_object_keywords(schema, schema_class)
+          return schema unless schema_class.respond_to?(:object_keywords)
+
+          schema.merge!(schema_class.object_keywords)
+        end
+
+        def pattern_source(pattern)
+          pattern.is_a?(Regexp) ? pattern.source : pattern.to_s
         end
       end
     end

--- a/lib/ruby_llm/schema/dsl/utilities.rb
+++ b/lib/ruby_llm/schema/dsl/utilities.rb
@@ -16,9 +16,26 @@ module RubyLLM
             additionalProperties: sub_schema.additional_properties
           }
 
-          merge_conditions(schema, sub_schema)
+          merge_schema_keywords(schema, sub_schema)
 
           definitions[name] = schema
+        end
+
+        def object_keywords
+          @object_keywords ||= {}
+        end
+
+        # Constrains the names of properties matching a pattern, as JSON Schema patternProperties
+        def keys_matching(pattern, &block)
+          pattern = pattern.source if pattern.is_a?(Regexp)
+
+          object_keywords[:patternProperties] ||= {}
+          object_keywords[:patternProperties][pattern] = collect_schemas_from_block(&block).first
+        end
+
+        # Constrains every property name, as JSON Schema propertyNames
+        def keys(&block)
+          object_keywords[:propertyNames] = collect_schemas_from_block(&block).first
         end
 
         def reference(schema_name)
@@ -30,6 +47,12 @@ module RubyLLM
         end
 
         private
+
+        # Merges everything a schema class collects beyond its properties: key constraints and conditionals
+        def merge_schema_keywords(schema, schema_class)
+          schema.merge!(schema_class.object_keywords)
+          merge_conditions(schema, schema_class)
+        end
 
         def add_property(name, definition, required:, requires: nil)
           property_name = name.to_sym

--- a/lib/ruby_llm/schema/json_output.rb
+++ b/lib/ruby_llm/schema/json_output.rb
@@ -18,7 +18,7 @@ module RubyLLM
         # Only include $defs if there are definitions
         schema_hash["$defs"] = self.class.definitions unless self.class.definitions.empty?
 
-        self.class.send(:merge_conditions, schema_hash, self.class)
+        self.class.send(:merge_schema_keywords, schema_hash, self.class)
 
         {
           name: @name,

--- a/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "object validation keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports object property count constraints" do
+    schema_class.object :metadata, min_properties: 1, max_properties: 5 do
+      string :name
+    end
+
+    metadata_schema = schema_class.properties[:metadata]
+
+    expect(metadata_schema[:minProperties]).to eq(1)
+    expect(metadata_schema[:maxProperties]).to eq(5)
+  end
+
+  it "supports patternProperties with keys_matching" do
+    schema_class.object :metadata do
+      keys_matching(/^x-/) do
+        string
+      end
+
+      keys_matching(/^count_/) do
+        integer minimum: 0
+      end
+    end
+
+    expect(schema_class.properties[:metadata][:patternProperties]).to eq({
+      "^x-" => {type: "string"},
+      "^count_" => {type: "integer", minimum: 0}
+    })
+  end
+
+  it "supports string patterns with keys_matching" do
+    schema_class.object :metadata do
+      keys_matching("^x-") do
+        string
+      end
+    end
+
+    expect(schema_class.properties[:metadata][:patternProperties]).to eq({"^x-" => {type: "string"}})
+  end
+
+  it "supports propertyNames with keys" do
+    schema_class.object :metadata do
+      keys do
+        string pattern: "^[a-z_]+$"
+      end
+    end
+
+    expect(schema_class.properties[:metadata][:propertyNames]).to eq({
+      type: "string",
+      pattern: "^[a-z_]+$"
+    })
+  end
+
+  it "includes object validation keywords in definitions" do
+    schema_class.define :metadata do
+      keys_matching(/^x-/) do
+        string
+      end
+
+      keys do
+        string pattern: "^[a-z_]+$"
+      end
+    end
+
+    definition = schema_class.definitions[:metadata]
+
+    expect(definition[:patternProperties]).to eq({"^x-" => {type: "string"}})
+    expect(definition[:propertyNames]).to eq({type: "string", pattern: "^[a-z_]+$"})
+  end
+
+  it "includes object validation keywords when embedding schema classes" do
+    metadata_schema = Class.new(described_class) do
+      keys_matching(/^x-/) do
+        string
+      end
+    end
+
+    schema_class.object :metadata, of: metadata_schema
+
+    expect(schema_class.properties[:metadata][:patternProperties]).to eq({
+      "^x-" => {type: "string"}
+    })
+  end
+
+  it "includes object validation keywords on the root schema" do
+    schema_class.keys do
+      string pattern: "^[a-z_]+$"
+    end
+
+    schema = schema_class.new.to_json_schema[:schema]
+
+    expect(schema[:propertyNames]).to eq({type: "string", pattern: "^[a-z_]+$"})
+  end
+end

--- a/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "object validation keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports object property count constraints" do
+    schema_class.object :metadata, min_properties: 1, max_properties: 5 do
+      string :name
+    end
+
+    metadata_schema = schema_class.properties[:metadata]
+
+    expect(metadata_schema[:minProperties]).to eq(1)
+    expect(metadata_schema[:maxProperties]).to eq(5)
+  end
+
+  it "supports patternProperties with keys_matching" do
+    schema_class.object :metadata do
+      keys_matching(/^x-/) do
+        string
+      end
+
+      keys_matching(/^count_/) do
+        integer minimum: 0
+      end
+    end
+
+    expect(schema_class.properties[:metadata][:patternProperties]).to eq({
+      "^x-" => {type: "string"},
+      "^count_" => {type: "integer", minimum: 0}
+    })
+  end
+
+  it "supports propertyNames with keys" do
+    schema_class.object :metadata do
+      keys do
+        string pattern: "^[a-z_]+$"
+      end
+    end
+
+    expect(schema_class.properties[:metadata][:propertyNames]).to eq({
+      type: "string",
+      pattern: "^[a-z_]+$"
+    })
+  end
+
+  it "includes object validation keywords in definitions" do
+    schema_class.define :metadata do
+      keys_matching(/^x-/) do
+        string
+      end
+
+      keys do
+        string pattern: "^[a-z_]+$"
+      end
+    end
+
+    definition = schema_class.definitions[:metadata]
+
+    expect(definition[:patternProperties]).to eq({"^x-" => {type: "string"}})
+    expect(definition[:propertyNames]).to eq({type: "string", pattern: "^[a-z_]+$"})
+  end
+
+  it "includes object validation keywords when embedding schema classes" do
+    metadata_schema = Class.new(described_class) do
+      keys_matching(/^x-/) do
+        string
+      end
+    end
+
+    schema_class.object :metadata, of: metadata_schema
+
+    expect(schema_class.properties[:metadata][:patternProperties]).to eq({
+      "^x-" => {type: "string"}
+    })
+  end
+end


### PR DESCRIPTION
Closes #35

## Summary
- Add `min_properties:` and `max_properties:` for object schemas
- Add `keys_matching` for `patternProperties`
- Add `keys` for `propertyNames`
- Merge object keyword fragments into inline objects, `$defs`, and embedded schema classes

## Verification
- `bundle exec rake`