### PR TITLE
Add array validation keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,27 @@ array :items do                       # Array of objects
     number :price
   end
 end
+
+array :tags, of: :string, unique: true  # No duplicate items
+
+array :scores do                      # At least one score of 10 or more
+  integer
+
+  contains min: 1 do
+    integer minimum: 10
+  end
+end
+```
+
+### Tuples
+
+A tuple is a fixed-length array where each position has its own schema. It emits `prefixItems` along with matching `minItems` and `maxItems`.
+
+```ruby
+tuple :coordinates do
+  number description: "Latitude"
+  number description: "Longitude"
+end
 ```
 
 ### Objects

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -93,7 +93,7 @@ module RubyLLM
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      %i[string number integer boolean array object any_of one_of all_of none_of null].include?(method_name) || super
+      %i[string number integer boolean array tuple object any_of one_of all_of none_of null].include?(method_name) || super
     end
   end
 end

--- a/lib/ruby_llm/schema/dsl/complex_types.rb
+++ b/lib/ruby_llm/schema/dsl/complex_types.rb
@@ -12,6 +12,10 @@ module RubyLLM
           add_property(name, array_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
+        def tuple(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, tuple_schema(description: description, **options, &block), required: required, requires: requires)
+        end
+
         def any_of(name, description: nil, required: true, requires: nil, **options, &block)
           add_property(name, any_of_schema(description: description, **options, &block), required: required, requires: requires)
         end

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -4,6 +4,9 @@ module RubyLLM
   class Schema
     module DSL
       module SchemaBuilders
+        # What a schema block yields: the schemas declared in it, and the keywords set on the enclosing node
+        SchemaBlock = Struct.new(:schemas, :keywords)
+
         def string_schema(description: nil, enum: nil, const: nil, min_length: nil, max_length: nil, pattern: nil, format: nil)
           {
             type: "string",
@@ -68,16 +71,29 @@ module RubyLLM
           }.compact)
         end
 
-        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, &block)
-          items = determine_array_items(of, &block)
+        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unique: nil, unevaluated_items: nil, &block)
+          schema_block = collect_schema_block(&block) if block
 
           {
             type: "array",
             description: description,
-            items: items,
+            items: determine_array_items(of, schema_block),
             minItems: min_items,
             maxItems: max_items,
+            uniqueItems: unique,
             unevaluatedItems: unevaluated_items
+          }.compact.merge(schema_block ? schema_block.keywords : {})
+        end
+
+        def tuple_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            type: "array",
+            description: description,
+            prefixItems: schemas,
+            minItems: schemas.length,
+            maxItems: schemas.length
           }.compact
         end
 
@@ -147,8 +163,8 @@ module RubyLLM
           end
         end
 
-        def determine_array_items(of, &)
-          return collect_schemas_from_block(&).first if block_given?
+        def determine_array_items(of, schema_block = nil)
+          return schema_block.schemas.first if schema_block
           return send("#{of}_schema") if primitive_type?(of)
           return reference(of) if of.is_a?(Symbol)
           return schema_class_to_inline_schema(of) if schema_class?(of)
@@ -175,8 +191,12 @@ module RubyLLM
           description ? result.merge(description: description) : result
         end
 
-        def collect_schemas_from_block(&block)
-          schemas = []
+        def collect_schemas_from_block(&)
+          collect_schema_block(&).schemas
+        end
+
+        def collect_schema_block(&block)
+          schema_block = SchemaBlock.new([], {})
           schema_builder = self
 
           context = Object.new
@@ -186,8 +206,16 @@ module RubyLLM
             type_name = schema_method.to_s.sub(/_schema$/, "")
 
             context.define_singleton_method(type_name) do |_name = nil, **options, &blk|
-              schemas << schema_builder.send(schema_method, **options, &blk)
+              schema_block.schemas << schema_builder.send(schema_method, **options, &blk)
             end
+          end
+
+          context.define_singleton_method(:contains) do |min: nil, max: nil, &blk|
+            schema_block.keywords.merge!({
+              contains: schema_builder.send(:collect_schemas_from_block, &blk).first,
+              minContains: min,
+              maxContains: max
+            }.compact)
           end
 
           # Allow Schema classes to be accessed in the context
@@ -196,7 +224,7 @@ module RubyLLM
           end
 
           context.instance_eval(&block)
-          schemas
+          schema_block
         end
 
         def schema_class_to_inline_schema(schema_class_or_instance)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -77,16 +77,33 @@ module RubyLLM
           schema
         end
 
-        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, &block)
-          items = determine_array_items(of, &block)
+        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, unique: nil, &block)
+          schema_block = collect_schema_block(&block) if block_given?
+          items = determine_array_items(of, schema_block)
 
-          {
+          schema = {
             type: "array",
             description: description,
             items: items,
             minItems: min_items,
             maxItems: max_items,
+            uniqueItems: unique,
             unevaluatedItems: unevaluated_items
+          }.compact
+
+          schema.merge!(schema_block.keywords) if schema_block
+          schema
+        end
+
+        def tuple_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            type: "array",
+            description: description,
+            prefixItems: schemas,
+            minItems: schemas.length,
+            maxItems: schemas.length
           }.compact
         end
 
@@ -140,8 +157,9 @@ module RubyLLM
           raise ArgumentError, "unknown #{type} schema option: #{options.keys.first.inspect}"
         end
 
-        def determine_array_items(of, &)
-          return collect_schemas_from_block(&).first if block_given?
+        def determine_array_items(of, schema_block = nil)
+          return schema_block.schemas.first if schema_block&.schemas&.any?
+          return nil if schema_block
           return send("#{of}_schema") if primitive_type?(of)
           return reference(of) if of.is_a?(Symbol)
           return schema_class_to_inline_schema(of) if schema_class?(of)
@@ -212,6 +230,12 @@ module RubyLLM
 
           context.define_singleton_method(:unevaluated_items) do |value|
             schema_block.keywords[:unevaluatedItems] = value
+          end
+
+          context.define_singleton_method(:contains) do |min: nil, max: nil, &blk|
+            schema_block.keywords[:contains] = schema_builder.send(:collect_schemas_from_block, &blk).first
+            schema_block.keywords[:minContains] = min unless min.nil?
+            schema_block.keywords[:maxContains] = max unless max.nil?
           end
 
           # Allow Schema classes to be accessed in the context

--- a/spec/ruby_llm/schema/properties/array_validation_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/array_validation_keywords_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "array validation keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports uniqueItems with homogeneous arrays" do
+    schema_class.array :tags, of: :string, unique: true
+
+    expect(schema_class.properties[:tags]).to eq({
+      type: "array",
+      items: {type: "string"},
+      uniqueItems: true
+    })
+  end
+
+  it "supports tuple schemas with prefixItems" do
+    schema_class.tuple :coordinates do
+      number description: "Latitude"
+      number description: "Longitude"
+    end
+
+    expect(schema_class.properties[:coordinates]).to eq({
+      type: "array",
+      prefixItems: [
+        {type: "number", description: "Latitude"},
+        {type: "number", description: "Longitude"}
+      ],
+      minItems: 2,
+      maxItems: 2
+    })
+  end
+
+  it "supports tuple schemas with object entries" do
+    schema_class.tuple :event do
+      string description: "Event name"
+      integer description: "Unix timestamp"
+      object description: "Payload" do
+        string :id
+        string :source
+      end
+    end
+
+    event_schema = schema_class.properties[:event]
+
+    expect(event_schema[:prefixItems].length).to eq(3)
+    expect(event_schema[:prefixItems][2][:properties][:id]).to eq({type: "string"})
+    expect(event_schema[:minItems]).to eq(3)
+    expect(event_schema[:maxItems]).to eq(3)
+  end
+
+  it "supports contains with minContains and maxContains" do
+    schema_class.array :scores do
+      contains min: 1, max: 3 do
+        integer minimum: 10
+      end
+    end
+
+    expect(schema_class.properties[:scores]).to eq({
+      type: "array",
+      contains: {type: "integer", minimum: 10},
+      minContains: 1,
+      maxContains: 3
+    })
+  end
+
+  it "keeps existing homogeneous item behavior" do
+    schema_class.array :items, of: :integer
+
+    expect(schema_class.properties[:items]).to eq({
+      type: "array",
+      items: {type: "integer"}
+    })
+  end
+end

--- a/spec/ruby_llm/schema/properties/array_validation_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/array_validation_keywords_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "array validation keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports uniqueItems with homogeneous arrays" do
+    schema_class.array :tags, of: :string, unique: true
+
+    expect(schema_class.properties[:tags]).to eq({
+      type: "array",
+      items: {type: "string"},
+      uniqueItems: true
+    })
+  end
+
+  it "supports tuple schemas with prefixItems" do
+    schema_class.tuple :coordinates do
+      number description: "Latitude"
+      number description: "Longitude"
+    end
+
+    expect(schema_class.properties[:coordinates]).to eq({
+      type: "array",
+      prefixItems: [
+        {type: "number", description: "Latitude"},
+        {type: "number", description: "Longitude"}
+      ],
+      minItems: 2,
+      maxItems: 2
+    })
+  end
+
+  it "supports tuple schemas with object entries" do
+    schema_class.tuple :event do
+      string description: "Event name"
+      integer description: "Unix timestamp"
+      object description: "Payload" do
+        string :id
+        string :source
+      end
+    end
+
+    event_schema = schema_class.properties[:event]
+
+    expect(event_schema[:prefixItems].length).to eq(3)
+    expect(event_schema[:prefixItems][2][:properties][:id]).to eq({type: "string"})
+    expect(event_schema[:minItems]).to eq(3)
+    expect(event_schema[:maxItems]).to eq(3)
+  end
+
+  it "supports contains with minContains and maxContains" do
+    schema_class.array :scores do
+      contains min: 1, max: 3 do
+        integer minimum: 10
+      end
+    end
+
+    expect(schema_class.properties[:scores]).to eq({
+      type: "array",
+      contains: {type: "integer", minimum: 10},
+      minContains: 1,
+      maxContains: 3
+    })
+  end
+
+  it "supports contains alongside an item schema" do
+    schema_class.array :scores do
+      integer
+
+      contains do
+        integer minimum: 10
+      end
+    end
+
+    expect(schema_class.properties[:scores]).to eq({
+      type: "array",
+      items: {type: "integer"},
+      contains: {type: "integer", minimum: 10}
+    })
+  end
+
+  it "keeps existing homogeneous item behavior" do
+    schema_class.array :items, of: :integer
+
+    expect(schema_class.properties[:items]).to eq({
+      type: "array",
+      items: {type: "integer"}
+    })
+  end
+end


### PR DESCRIPTION
Closes #36

## Summary
- Add `unique:` support for `uniqueItems`
- Add `tuple` schemas backed by `prefixItems`
- Add array block `contains` support with `minContains` / `maxContains`
- Cover tuple objects and preserve existing homogeneous array behavior

## Verification
- `bundle exec rake`