### PR TITLE
Add content annotation keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,25 @@ string :role, const: "admin"
 string :code, min_length: 3, max_length: 10
 ```
 
+### Encoded String Content
+
+Strings that carry encoded content can describe what is inside them.
+
+- `content_encoding`: how the string is encoded (e.g. `content_encoding: "base64"`)
+- `content_media_type`: the media type of the decoded content (e.g. `content_media_type: "application/json"`)
+- `content_schema`: a block describing the schema of the decoded content
+
+```ruby
+string :payload, content_encoding: "base64", content_media_type: "application/json" do
+  content_schema do
+    object do
+      string :name
+      string :email
+    end
+  end
+end
+```
+
 ### Numbers
 
 Number and integer types support the following properties:

--- a/lib/ruby_llm/schema/dsl/primitive_types.rb
+++ b/lib/ruby_llm/schema/dsl/primitive_types.rb
@@ -4,8 +4,8 @@ module RubyLLM
   class Schema
     module DSL
       module PrimitiveTypes
-        def string(name, description: nil, required: true, requires: nil, **options)
-          add_property(name, string_schema(description: description, **options), required: required, requires: requires)
+        def string(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, string_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
         def number(name, description: nil, required: true, requires: nil, **options)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -15,21 +15,28 @@ module RubyLLM
         }.freeze
         SchemaBlock = Struct.new(:schemas, :keywords, keyword_init: true)
 
-        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options)
+        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options, &block)
           metadata = extract_metadata!(options)
           format = options.delete(:format)
           const = options.delete(:const) { NOT_GIVEN }
+          content_encoding = options.delete(:content_encoding)
+          content_media_type = options.delete(:content_media_type)
           raise_unknown_options!("string", options)
+          schema_block = collect_schema_block(&block) if block_given?
 
-          add_const(metadata.merge({
+          schema = add_const(metadata.merge({
             type: "string",
             enum: enum,
             description: description,
             minLength: min_length,
             maxLength: max_length,
             pattern: pattern,
-            format: format
+            format: format,
+            contentEncoding: content_encoding,
+            contentMediaType: content_media_type
           }.compact), const)
+
+          merge_schema_block_keywords(schema, schema_block)
         end
 
         def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
@@ -313,6 +320,10 @@ module RubyLLM
             schema_block.keywords[:contains] = schema_builder.send(:collect_schemas_from_block, &blk).first
             schema_block.keywords[:minContains] = min unless min.nil?
             schema_block.keywords[:maxContains] = max unless max.nil?
+          end
+
+          context.define_singleton_method(:content_schema) do |&blk|
+            schema_block.keywords[:contentSchema] = schema_builder.send(:collect_schemas_from_block, &blk).first
           end
 
           context.define_singleton_method(:description) do |value|

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -7,7 +7,9 @@ module RubyLLM
         # What a schema block yields: the schemas declared in it, and the keywords set on the enclosing node
         SchemaBlock = Struct.new(:schemas, :keywords)
 
-        def string_schema(description: nil, enum: nil, const: nil, min_length: nil, max_length: nil, pattern: nil, format: nil, **annotations)
+        def string_schema(description: nil, enum: nil, const: nil, min_length: nil, max_length: nil, pattern: nil, format: nil, content_encoding: nil, content_media_type: nil, **annotations, &block)
+          schema_block = collect_schema_block(&block) if block
+
           annotate({
             type: "string",
             enum: enum,
@@ -16,8 +18,10 @@ module RubyLLM
             minLength: min_length,
             maxLength: max_length,
             pattern: pattern,
-            format: format
-          }.compact, annotations)
+            format: format,
+            contentEncoding: content_encoding,
+            contentMediaType: content_media_type
+          }.compact, annotations, schema_block)
         end
 
         def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil, enum: nil, const: nil, **annotations)
@@ -227,6 +231,10 @@ module RubyLLM
               minContains: min,
               maxContains: max
             }.compact)
+          end
+
+          context.define_singleton_method(:content_schema) do |&blk|
+            schema_block.keywords[:contentSchema] = schema_builder.send(:collect_schemas_from_block, &blk).first
           end
 
           # Annotations set here describe the schema the block belongs to, not the schemas declared inside it

--- a/spec/ruby_llm/schema/properties/content_annotations_spec.rb
+++ b/spec/ruby_llm/schema/properties/content_annotations_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "content annotations" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports contentEncoding and contentMediaType keywords" do
+    schema_class.string :payload,
+                        content_encoding: "base64",
+                        content_media_type: "application/json"
+
+    expect(schema_class.properties[:payload]).to eq({
+      type: "string",
+      contentEncoding: "base64",
+      contentMediaType: "application/json"
+    })
+  end
+
+  it "supports nested contentSchema blocks" do
+    schema_class.string :payload,
+                        content_encoding: "base64",
+                        content_media_type: "application/json" do
+      content_schema do
+        object do
+          title "Payload"
+          description "Decoded JSON payload"
+
+          string :name
+        end
+      end
+    end
+
+    payload_schema = schema_class.properties[:payload]
+
+    expect(payload_schema[:contentSchema]).to include(
+      type: "object",
+      title: "Payload",
+      description: "Decoded JSON payload"
+    )
+    expect(payload_schema[:contentSchema][:properties][:name]).to eq({type: "string"})
+  end
+
+  it "supports a primitive contentSchema" do
+    schema_class.string :payload, content_media_type: "text/plain" do
+      content_schema do
+        string pattern: "^[a-z]+$"
+      end
+    end
+
+    expect(schema_class.properties[:payload][:contentSchema]).to eq({type: "string", pattern: "^[a-z]+$"})
+  end
+
+  it "supports metadata on the encoded string node" do
+    schema_class.string :payload, title: "Encoded payload" do
+      content_schema do
+        object do
+          string :name
+        end
+      end
+    end
+
+    payload_schema = schema_class.properties[:payload]
+
+    expect(payload_schema[:title]).to eq("Encoded payload")
+    expect(payload_schema[:contentSchema][:properties][:name]).to eq({type: "string"})
+  end
+end

--- a/spec/ruby_llm/schema/properties/content_annotations_spec.rb
+++ b/spec/ruby_llm/schema/properties/content_annotations_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "content annotations" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports contentEncoding and contentMediaType keywords" do
+    schema_class.string :payload,
+                        content_encoding: "base64",
+                        content_media_type: "application/json"
+
+    expect(schema_class.properties[:payload]).to eq({
+      type: "string",
+      contentEncoding: "base64",
+      contentMediaType: "application/json"
+    })
+  end
+
+  it "supports nested contentSchema blocks" do
+    schema_class.string :payload,
+                        content_encoding: "base64",
+                        content_media_type: "application/json" do
+      content_schema do
+        object do
+          title "Payload"
+          description "Decoded JSON payload"
+
+          string :name
+        end
+      end
+    end
+
+    payload_schema = schema_class.properties[:payload]
+
+    expect(payload_schema[:contentSchema]).to include(
+      type: "object",
+      title: "Payload",
+      description: "Decoded JSON payload"
+    )
+    expect(payload_schema[:contentSchema][:properties][:name]).to eq({type: "string"})
+  end
+
+  it "supports metadata on the encoded string node" do
+    schema_class.string :payload, title: "Encoded payload" do
+      content_schema do
+        object do
+          string :name
+        end
+      end
+    end
+
+    payload_schema = schema_class.properties[:payload]
+
+    expect(payload_schema[:title]).to eq("Encoded payload")
+    expect(payload_schema[:contentSchema][:properties][:name]).to eq({type: "string"})
+  end
+end


### PR DESCRIPTION
Closes #41

## Summary
- Add `content_encoding:` and `content_media_type:` for string schemas
- Add string-block `content_schema` support
- Keep nested `content_schema` compatible with current-node metadata annotations

## Verification
- `bundle exec rake`