### PR TITLE
Add core identifier and reference keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,31 @@ class MySchema < RubyLLM::Schema
 end
 ```
 
+### Core Keywords
+
+Use core keywords when a schema or subschema needs an identifier, anchor, comment, dynamic reference, or vocabulary declaration.
+
+```ruby
+class Node < RubyLLM::Schema
+  id "https://example.com/schemas/node"
+  comment "Internal note"
+  dynamic_anchor "node"
+  vocabulary "https://json-schema.org/draft/2020-12/vocab/core" => true
+
+  define :address do
+    anchor "address"
+
+    string :street
+  end
+
+  object :child do
+    dynamic_ref "#node"
+  end
+end
+```
+
+`dynamic_ref` and `dynamic_anchor` are emitted verbatim. Their recursive resolution is the validator's job; this gem does not expand or interpret them.
+
 ### Nested Schemas
 
 You can embed existing schema classes directly within objects or arrays for reusable schema composition.

--- a/README.md
+++ b/README.md
@@ -385,6 +385,28 @@ class MySchema < RubyLLM::Schema
 end
 ```
 
+### Core Keywords
+
+Use core keyword methods when a schema or subschema needs an identifier, anchor, comment, dynamic reference, or vocabulary declaration:
+
+```ruby
+id "https://example.com/schemas/person"
+anchor "person"
+comment "Internal note"
+dynamic_anchor "node"
+dynamic_ref "#node"
+vocabulary "https://json-schema.org/draft/2020-12/vocab/core" => true
+
+define :address do
+  anchor "address"
+  comment "Reusable address schema"
+
+  string :street
+end
+```
+
+`dynamic_ref` and `dynamic_anchor` are emitted as JSON Schema core keywords. Their recursive resolution semantics are handled by JSON Schema validators; this gem does not expand or interpret dynamic references.
+
 ### Nested Schemas
 
 You can embed existing schema classes directly within objects or arrays for reusable schema composition.

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -26,6 +26,16 @@ module RubyLLM
       write_only: :writeOnly
     }.freeze
 
+    # Core keywords identify a schema and point at other schemas.
+    CORE_KEYWORDS = {
+      id: "$id",
+      anchor: "$anchor",
+      comment: "$comment",
+      dynamic_anchor: "$dynamicAnchor",
+      dynamic_ref: "$dynamicRef",
+      vocabulary: "$vocabulary"
+    }.freeze
+
     class << self
       def create(&block)
         schema_class = Class.new(Schema)
@@ -84,6 +94,34 @@ module RubyLLM
         annotation(:write_only, *args)
       end
 
+      def core_keywords
+        @core_keywords ||= {}
+      end
+
+      def id(*args)
+        core_keyword(:id, *args)
+      end
+
+      def anchor(*args)
+        core_keyword(:anchor, *args)
+      end
+
+      def comment(*args)
+        core_keyword(:comment, *args)
+      end
+
+      def dynamic_anchor(*args)
+        core_keyword(:dynamic_anchor, *args)
+      end
+
+      def dynamic_ref(*args)
+        core_keyword(:dynamic_ref, *args)
+      end
+
+      def vocabulary(*args)
+        core_keyword(:vocabulary, *args)
+      end
+
       def additional_properties(value = nil)
         return @additional_properties ||= false if value.nil?
 
@@ -111,10 +149,17 @@ module RubyLLM
       private
 
       def annotation(name, *args)
-        keyword = ANNOTATIONS.fetch(name)
-        return annotations[keyword] if args.empty?
+        read_or_write(annotations, ANNOTATIONS.fetch(name), *args)
+      end
 
-        annotations[keyword] = args.first
+      def core_keyword(name, *args)
+        read_or_write(core_keywords, CORE_KEYWORDS.fetch(name), *args)
+      end
+
+      def read_or_write(store, keyword, *args)
+        return store[keyword] if args.empty?
+
+        store[keyword] = args.first
       end
     end
 

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -14,6 +14,14 @@ module RubyLLM
     include JsonOutput
 
     PRIMITIVE_TYPES = %i[string number integer boolean null].freeze
+    CORE_KEYWORDS = {
+      id: "$id",
+      anchor: "$anchor",
+      comment: "$comment",
+      dynamic_anchor: "$dynamicAnchor",
+      dynamic_ref: "$dynamicRef",
+      vocabulary: "$vocabulary"
+    }.freeze
 
     class << self
       def create(&block)
@@ -38,6 +46,10 @@ module RubyLLM
         @schema_metadata ||= {}
       end
 
+      def schema_core_keywords
+        @schema_core_keywords ||= {}
+      end
+
       def name(name = nil)
         @schema_name = name if name
         return @schema_name if defined?(@schema_name)
@@ -47,6 +59,30 @@ module RubyLLM
 
       def title(*args)
         metadata_accessor(:title, *args)
+      end
+
+      def id(*args)
+        core_keyword_accessor("$id", *args)
+      end
+
+      def anchor(*args)
+        core_keyword_accessor("$anchor", *args)
+      end
+
+      def comment(*args)
+        core_keyword_accessor("$comment", *args)
+      end
+
+      def dynamic_anchor(*args)
+        core_keyword_accessor("$dynamicAnchor", *args)
+      end
+
+      def dynamic_ref(*args)
+        core_keyword_accessor("$dynamicRef", *args)
+      end
+
+      def vocabulary(*args)
+        core_keyword_accessor("$vocabulary", *args)
       end
 
       def description(description = nil)
@@ -108,6 +144,12 @@ module RubyLLM
         return schema_metadata[keyword] if args.empty?
 
         schema_metadata[keyword] = args.first
+      end
+
+      def core_keyword_accessor(keyword, *args)
+        return schema_core_keywords[keyword] if args.empty?
+
+        schema_core_keywords[keyword] = args.first
       end
     end
 

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -234,6 +234,12 @@ module RubyLLM
           schema.replace(schema_class.schema_metadata.merge(schema))
         end
 
+        def merge_core_keywords(schema, schema_class)
+          return schema unless schema_class.respond_to?(:schema_core_keywords)
+
+          schema.merge!(schema_class.schema_core_keywords)
+        end
+
         def raise_unknown_options!(type, options)
           return if options.empty?
 
@@ -266,6 +272,7 @@ module RubyLLM
           }.compact
 
           merge_schema_metadata(schema, sub_schema)
+          merge_core_keywords(schema, sub_schema)
           merge_conditions(schema, sub_schema)
           merge_object_keywords(schema, sub_schema)
         end
@@ -336,6 +343,12 @@ module RubyLLM
             end
           end
 
+          RubyLLM::Schema::CORE_KEYWORDS.each do |method_name, keyword|
+            context.define_singleton_method(method_name) do |value|
+              schema_block.keywords[keyword] = value
+            end
+          end
+
           # Allow Schema classes to be accessed in the context
           context.define_singleton_method(:const_missing) do |name|
             const_get(name) if const_defined?(name)
@@ -368,6 +381,7 @@ module RubyLLM
                           end
 
             merge_schema_metadata(schema, schema_class)
+            merge_core_keywords(schema, schema_class)
             schema[:description] = description if description
 
             merge_conditions(schema, schema_class)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -237,8 +237,9 @@ module RubyLLM
             schema_block.keywords[:contentSchema] = schema_builder.send(:collect_schemas_from_block, &blk).first
           end
 
-          # Annotations set here describe the schema the block belongs to, not the schemas declared inside it
-          ANNOTATIONS.each do |name, keyword|
+          # Annotations and core keywords set here describe the schema the block belongs to,
+          # not the schemas declared inside it
+          ANNOTATIONS.merge(CORE_KEYWORDS).each do |name, keyword|
             context.define_singleton_method(name) do |value|
               schema_block.keywords[keyword] = value
             end

--- a/lib/ruby_llm/schema/dsl/utilities.rb
+++ b/lib/ruby_llm/schema/dsl/utilities.rb
@@ -48,10 +48,12 @@ module RubyLLM
 
         private
 
-        # Merges everything a schema class collects beyond its properties: annotations, key constraints, conditionals.
-        # Annotations are defaults, so an option passed to the enclosing builder wins over them.
+        # Merges everything a schema class collects beyond its properties: annotations, core keywords,
+        # key constraints, conditionals. Annotations are defaults, so an option passed to the enclosing
+        # builder wins over them.
         def merge_schema_keywords(schema, schema_class)
           schema.replace(schema_class.annotations.merge(schema))
+          schema.merge!(schema_class.core_keywords)
           schema.merge!(schema_class.object_keywords)
           merge_conditions(schema, schema_class)
         end

--- a/lib/ruby_llm/schema/dsl/utilities.rb
+++ b/lib/ruby_llm/schema/dsl/utilities.rb
@@ -17,6 +17,7 @@ module RubyLLM
           }
 
           merge_schema_metadata(schema, sub_schema)
+          merge_core_keywords(schema, sub_schema)
           merge_object_keywords(schema, sub_schema)
           merge_conditions(schema, sub_schema)
 

--- a/lib/ruby_llm/schema/json_output.rb
+++ b/lib/ruby_llm/schema/json_output.rb
@@ -19,6 +19,7 @@ module RubyLLM
         schema_hash["$defs"] = self.class.definitions unless self.class.definitions.empty?
 
         self.class.send(:merge_conditions, schema_hash, self.class)
+        self.class.send(:merge_core_keywords, schema_hash, self.class)
 
         {
           name: @name,

--- a/spec/ruby_llm/schema/properties/core_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/core_keywords_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "core keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports root schema core keywords" do
+    schema_class.id "https://example.com/schemas/person"
+    schema_class.anchor "person"
+    schema_class.comment "Internal note"
+    schema_class.dynamic_anchor "node"
+    schema_class.dynamic_ref "#node"
+    schema_class.vocabulary "https://json-schema.org/draft/2020-12/vocab/core" => true
+
+    schema = schema_class.new.to_json_schema[:schema]
+
+    expect(schema).to include(
+      "$id" => "https://example.com/schemas/person",
+      "$anchor" => "person",
+      "$comment" => "Internal note",
+      "$dynamicAnchor" => "node",
+      "$dynamicRef" => "#node",
+      "$vocabulary" => {"https://json-schema.org/draft/2020-12/vocab/core" => true}
+    )
+  end
+
+  it "reads back core keywords" do
+    schema_class.id "https://example.com/schemas/person"
+
+    expect(schema_class.id).to eq("https://example.com/schemas/person")
+  end
+
+  it "supports core keywords inside definitions" do
+    schema_class.define :address do
+      anchor "address"
+      comment "Reusable address schema"
+
+      string :street
+    end
+
+    definition = schema_class.definitions[:address]
+
+    expect(definition["$anchor"]).to eq("address")
+    expect(definition["$comment"]).to eq("Reusable address schema")
+    expect(definition[:properties][:street]).to eq({type: "string"})
+  end
+
+  it "supports core keywords inside inline object schemas" do
+    schema_class.object :node do
+      dynamic_anchor "node"
+
+      string :name
+    end
+
+    expect(schema_class.properties[:node]["$dynamicAnchor"]).to eq("node")
+  end
+
+  it "supports core keywords inside composition blocks" do
+    schema_class.any_of :value do
+      comment "Either shape is accepted"
+
+      string
+      integer
+    end
+
+    expect(schema_class.properties[:value]["$comment"]).to eq("Either shape is accepted")
+  end
+
+  it "supports core keywords on embedded schema classes" do
+    address_schema = Class.new(described_class) do
+      anchor "address"
+
+      string :street
+    end
+
+    schema_class.object :address, of: address_schema
+
+    expect(schema_class.properties[:address]["$anchor"]).to eq("address")
+  end
+end

--- a/spec/ruby_llm/schema/properties/core_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/core_keywords_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "core keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports root schema core keywords" do
+    schema_class.id "https://example.com/schemas/person"
+    schema_class.anchor "person"
+    schema_class.comment "Internal note"
+    schema_class.dynamic_anchor "node"
+    schema_class.dynamic_ref "#node"
+    schema_class.vocabulary "https://json-schema.org/draft/2020-12/vocab/core" => true
+
+    schema = schema_class.new.to_json_schema[:schema]
+
+    expect(schema).to include(
+      "$id" => "https://example.com/schemas/person",
+      "$anchor" => "person",
+      "$comment" => "Internal note",
+      "$dynamicAnchor" => "node",
+      "$dynamicRef" => "#node",
+      "$vocabulary" => {"https://json-schema.org/draft/2020-12/vocab/core" => true}
+    )
+  end
+
+  it "supports core keywords inside definitions" do
+    schema_class.define :address do
+      anchor "address"
+      comment "Reusable address schema"
+
+      string :street
+    end
+
+    definition = schema_class.definitions[:address]
+
+    expect(definition["$anchor"]).to eq("address")
+    expect(definition["$comment"]).to eq("Reusable address schema")
+  end
+
+  it "supports core keywords inside nested object schemas" do
+    schema_class.object :node do
+      dynamic_anchor "node"
+
+      string :value
+    end
+
+    node_schema = schema_class.properties[:node]
+
+    expect(node_schema["$dynamicAnchor"]).to eq("node")
+    expect(node_schema[:properties][:value]).to eq({type: "string"})
+  end
+
+  it "supports core keywords on composition schemas" do
+    schema_class.any_of :identifier do
+      comment "Accepted identifier formats"
+
+      string
+      integer
+    end
+
+    identifier_schema = schema_class.properties[:identifier]
+
+    expect(identifier_schema["$comment"]).to eq("Accepted identifier formats")
+    expect(identifier_schema[:anyOf].map { |schema| schema[:type] }).to eq(%w[string integer])
+  end
+end


### PR DESCRIPTION
Closes #39

## Summary
- Add root and nested support for `$id`, `$anchor`, `$comment`, `$dynamicAnchor`, `$dynamicRef`, and `$vocabulary`
- Merge core keywords into `$defs`, inline object schemas, embedded schema classes, composition blocks, and root output
- Document dynamic reference behavior as emitted verbatim for JSON Schema validators

## Verification
- `bundle exec rake`