### PR TITLE
Add boolean and raw schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,28 @@ object :profile, of: :person, unevaluated_properties: false
 array :values, of: :integer, unevaluated_items: false
 ```
 
+### Boolean and Raw Schemas
+
+JSON Schema allows `true` and `false` in place of a schema object: `true` accepts every value, `false` accepts none. Inside a block, `any_schema` and `no_schema` emit them.
+
+```ruby
+any_of :value do
+  any_schema
+  string
+end
+```
+
+When you need a keyword this DSL doesn't cover, `raw` emits a fragment verbatim.
+
+```ruby
+raw :role, { type: "string", const: "admin" }
+
+any_of :value do
+  raw type: "string", const: "admin"
+  integer
+end
+```
+
 ### Schema Definitions and References
 
 You can define sub-schemas and reference them in other schemas, or reference the root schema to generate recursive schemas.

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -175,7 +175,7 @@ module RubyLLM
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      %i[string number integer boolean array tuple object any_of one_of all_of none_of null].include?(method_name) || super
+      %i[string number integer boolean array tuple object any_of one_of all_of none_of raw null].include?(method_name) || super
     end
   end
 end

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -185,7 +185,7 @@ module RubyLLM
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      %i[string number integer boolean array tuple object any_of one_of all_of none_of null].include?(method_name) || super
+      %i[string number integer boolean array tuple object any_of one_of all_of none_of raw null].include?(method_name) || super
     end
   end
 end

--- a/lib/ruby_llm/schema/dsl/complex_types.rb
+++ b/lib/ruby_llm/schema/dsl/complex_types.rb
@@ -32,6 +32,10 @@ module RubyLLM
           add_property(name, none_of_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
+        def raw(name, schema, required: true, requires: nil)
+          add_property(name, normalize_raw_schema(schema), required: required, requires: requires)
+        end
+
         def optional(name, description: nil, &block)
           any_of(name, description: description) do
             instance_eval(&block)

--- a/lib/ruby_llm/schema/dsl/complex_types.rb
+++ b/lib/ruby_llm/schema/dsl/complex_types.rb
@@ -32,6 +32,11 @@ module RubyLLM
           add_property(name, none_of_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
+        # Emits a schema fragment verbatim, for the corners of JSON Schema this DSL does not cover
+        def raw(name, schema, required: true, requires: nil)
+          add_property(name, schema, required: required, requires: requires)
+        end
+
         def optional(name, description: nil, &block)
           any_of(name, description: description) do
             instance_eval(&block)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -203,7 +203,7 @@ module RubyLLM
 
           schema = metadata.merge({
             description: description,
-            not: schemas.one? ? schemas.first : {anyOf: schemas}
+            not: schemas.length == 1 ? schemas.first : {anyOf: schemas}
           }.compact)
 
           merge_schema_block_keywords(schema, schema_block)
@@ -238,6 +238,19 @@ module RubyLLM
           return schema unless schema_class.respond_to?(:schema_core_keywords)
 
           schema.merge!(schema_class.schema_core_keywords)
+        end
+
+        def normalize_raw_schema(schema)
+          case schema
+          when Hash
+            schema.each_with_object({}) do |(key, value), normalized|
+              normalized[key.is_a?(Symbol) ? key.to_s : key] = normalize_raw_schema(value)
+            end
+          when Array
+            schema.map { |value| normalize_raw_schema(value) }
+          else
+            schema
+          end
         end
 
         def raise_unknown_options!(type, options)
@@ -331,6 +344,18 @@ module RubyLLM
 
           context.define_singleton_method(:content_schema) do |&blk|
             schema_block.keywords[:contentSchema] = schema_builder.send(:collect_schemas_from_block, &blk).first
+          end
+
+          context.define_singleton_method(:any_schema) do
+            schema_block.schemas << true
+          end
+
+          context.define_singleton_method(:no_schema) do
+            schema_block.schemas << false
+          end
+
+          context.define_singleton_method(:raw) do |schema|
+            schema_block.schemas << schema_builder.send(:normalize_raw_schema, schema)
           end
 
           context.define_singleton_method(:description) do |value|

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -233,6 +233,19 @@ module RubyLLM
             }.compact)
           end
 
+          # The two boolean schemas: true accepts every value, false accepts none
+          context.define_singleton_method(:any_schema) do
+            schema_block.schemas << true
+          end
+
+          context.define_singleton_method(:no_schema) do
+            schema_block.schemas << false
+          end
+
+          context.define_singleton_method(:raw) do |schema|
+            schema_block.schemas << schema
+          end
+
           context.define_singleton_method(:content_schema) do |&blk|
             schema_block.keywords[:contentSchema] = schema_builder.send(:collect_schemas_from_block, &blk).first
           end

--- a/spec/ruby_llm/schema/properties/boolean_and_raw_schemas_spec.rb
+++ b/spec/ruby_llm/schema/properties/boolean_and_raw_schemas_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "boolean and raw schemas" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports true schemas inside composition" do
+    schema_class.any_of :value do
+      any_schema
+      string
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      anyOf: [
+        true,
+        {type: "string"}
+      ]
+    })
+  end
+
+  it "supports false schemas inside composition" do
+    schema_class.none_of :value do
+      no_schema
+    end
+
+    expect(schema_class.properties[:value]).to eq({not: false})
+  end
+
+  it "supports true schemas as array items" do
+    schema_class.array :values do
+      any_schema
+    end
+
+    expect(schema_class.properties[:values]).to eq({type: "array", items: true})
+  end
+
+  it "supports raw schema properties" do
+    schema_class.raw :role, {
+      type: "string",
+      const: "admin"
+    }
+
+    expect(schema_class.properties[:role]).to eq({
+      type: "string",
+      const: "admin"
+    })
+  end
+
+  it "emits raw schemas verbatim" do
+    schema_class.raw :payload, {
+      "type" => "object",
+      "properties" => {"role" => {"const" => "admin"}}
+    }
+
+    expect(schema_class.properties[:payload]).to eq({
+      "type" => "object",
+      "properties" => {"role" => {"const" => "admin"}}
+    })
+  end
+
+  it "supports anonymous raw schemas inside composition" do
+    schema_class.any_of :value do
+      raw type: "string", const: "admin"
+      integer
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      anyOf: [
+        {type: "string", const: "admin"},
+        {type: "integer"}
+      ]
+    })
+  end
+end

--- a/spec/ruby_llm/schema/properties/boolean_and_raw_schemas_spec.rb
+++ b/spec/ruby_llm/schema/properties/boolean_and_raw_schemas_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "boolean and raw schemas" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports true schemas inside composition" do
+    schema_class.any_of :value do
+      any_schema
+      string
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      anyOf: [
+        true,
+        {type: "string"}
+      ]
+    })
+  end
+
+  it "supports false schemas inside composition" do
+    schema_class.none_of :value do
+      no_schema
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      not: false
+    })
+  end
+
+  it "supports raw schema properties" do
+    schema_class.raw :role, {
+      "type" => "string",
+      "const" => "admin"
+    }
+
+    expect(schema_class.properties[:role]).to eq({
+      "type" => "string",
+      "const" => "admin"
+    })
+  end
+
+  it "normalizes symbol keys inside raw schemas" do
+    schema_class.raw :payload, {
+      type: "object",
+      properties: {
+        role: {const: "admin"}
+      }
+    }
+
+    expect(schema_class.properties[:payload]).to eq({
+      "type" => "object",
+      "properties" => {
+        "role" => {"const" => "admin"}
+      }
+    })
+  end
+
+  it "supports anonymous raw schemas inside composition" do
+    schema_class.any_of :value do
+      raw type: "string", const: "admin"
+      integer
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      anyOf: [
+        {"type" => "string", "const" => "admin"},
+        {type: "integer"}
+      ]
+    })
+  end
+end


### PR DESCRIPTION
Closes #42

## Summary
- Add `any_schema` and `no_schema` helpers for boolean subschemas
- Add `raw` schema properties and anonymous raw subschemas
- Normalize symbol keys in raw schema fragments recursively
- Fix `none_of` single-schema handling for false boolean schemas

## Verification
- `bundle exec rake`