### PR TITLE
Add numeric enum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,40 @@ boolean :is_active, description: "Whether the person is active"
 null :placeholder, description: "A placeholder property"
 ```
 
+### Metadata Annotations
+
+Metadata annotations describe schemas for humans and tools. They do not usually affect validation.
+
+Supported annotations are `title`, `description`, `default`, `examples`, `deprecated`, `read_only`, and `write_only`.
+
+Short annotations can be passed as keyword arguments:
+
+```ruby
+string :email,
+  title: "Email address",
+  description: "Primary contact email",
+  default: "user@example.com",
+  examples: ["alice@example.com"],
+  deprecated: false,
+  read_only: false,
+  write_only: false
+```
+
+Longer annotations can live inside complex schema blocks:
+
+```ruby
+object :account do
+  title "Account"
+  description "Billing account metadata used for invoices."
+  examples [{ id: "acct_123", status: "active" }]
+
+  string :id
+  string :status
+end
+```
+
+Block annotations configure the enclosing schema node. If the same annotation is provided both as a keyword and inside the block, the keyword value wins.
+
 ⚠️ Please consult the LLM provider documentation for any limitations or restrictions. For example, as of now, OpenAI requires all properties to be required. In that case, you can use the `any_of` method to make a property optional.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -385,6 +385,28 @@ class MySchema < RubyLLM::Schema
 end
 ```
 
+### Core Keywords
+
+Use core keyword methods when a schema or subschema needs an identifier, anchor, comment, dynamic reference, or vocabulary declaration:
+
+```ruby
+id "https://example.com/schemas/person"
+anchor "person"
+comment "Internal note"
+dynamic_anchor "node"
+dynamic_ref "#node"
+vocabulary "https://json-schema.org/draft/2020-12/vocab/core" => true
+
+define :address do
+  anchor "address"
+  comment "Reusable address schema"
+
+  string :street
+end
+```
+
+`dynamic_ref` and `dynamic_anchor` are emitted as JSON Schema core keywords. Their recursive resolution semantics are handled by JSON Schema validators; this gem does not expand or interpret dynamic references.
+
 ### Nested Schemas
 
 You can embed existing schema classes directly within objects or arrays for reusable schema composition.

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -175,7 +175,7 @@ module RubyLLM
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      %i[string number integer boolean array tuple object any_of one_of all_of none_of null].include?(method_name) || super
+      %i[string number integer boolean array tuple object any_of one_of all_of none_of raw null].include?(method_name) || super
     end
   end
 end

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -93,7 +93,7 @@ module RubyLLM
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      %i[string number integer boolean array object any_of one_of null].include?(method_name) || super
+      %i[string number integer boolean array object any_of one_of all_of none_of null].include?(method_name) || super
     end
   end
 end

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -34,6 +34,10 @@ module RubyLLM
         @definitions ||= {}
       end
 
+      def schema_metadata
+        @schema_metadata ||= {}
+      end
+
       def name(name = nil)
         @schema_name = name if name
         return @schema_name if defined?(@schema_name)
@@ -41,9 +45,37 @@ module RubyLLM
         super()
       end
 
+      def title(*args)
+        metadata_accessor(:title, *args)
+      end
+
       def description(description = nil)
-        @description = description if description
+        if description
+          @description = description
+          schema_metadata[:description] = description
+        end
+
         @description
+      end
+
+      def default(*args)
+        metadata_accessor(:default, *args)
+      end
+
+      def examples(*args)
+        metadata_accessor(:examples, *args)
+      end
+
+      def deprecated(*args)
+        metadata_accessor(:deprecated, *args)
+      end
+
+      def read_only(*args)
+        metadata_accessor(:readOnly, *args)
+      end
+
+      def write_only(*args)
+        metadata_accessor(:writeOnly, *args)
       end
 
       def additional_properties(value = nil)
@@ -68,6 +100,14 @@ module RubyLLM
       def valid?
         validator = Validator.new(self)
         validator.valid?
+      end
+
+      private
+
+      def metadata_accessor(keyword, *args)
+        return schema_metadata[keyword] if args.empty?
+
+        schema_metadata[keyword] = args.first
       end
     end
 

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -14,6 +14,14 @@ module RubyLLM
     include JsonOutput
 
     PRIMITIVE_TYPES = %i[string number integer boolean null].freeze
+    CORE_KEYWORDS = {
+      id: "$id",
+      anchor: "$anchor",
+      comment: "$comment",
+      dynamic_anchor: "$dynamicAnchor",
+      dynamic_ref: "$dynamicRef",
+      vocabulary: "$vocabulary"
+    }.freeze
 
     class << self
       def create(&block)
@@ -38,6 +46,10 @@ module RubyLLM
         @schema_metadata ||= {}
       end
 
+      def schema_core_keywords
+        @schema_core_keywords ||= {}
+      end
+
       def name(name = nil)
         @schema_name = name if name
         return @schema_name if defined?(@schema_name)
@@ -47,6 +59,30 @@ module RubyLLM
 
       def title(*args)
         metadata_accessor(:title, *args)
+      end
+
+      def id(*args)
+        core_keyword_accessor("$id", *args)
+      end
+
+      def anchor(*args)
+        core_keyword_accessor("$anchor", *args)
+      end
+
+      def comment(*args)
+        core_keyword_accessor("$comment", *args)
+      end
+
+      def dynamic_anchor(*args)
+        core_keyword_accessor("$dynamicAnchor", *args)
+      end
+
+      def dynamic_ref(*args)
+        core_keyword_accessor("$dynamicRef", *args)
+      end
+
+      def vocabulary(*args)
+        core_keyword_accessor("$vocabulary", *args)
       end
 
       def description(description = nil)
@@ -108,6 +144,12 @@ module RubyLLM
         return schema_metadata[keyword] if args.empty?
 
         schema_metadata[keyword] = args.first
+      end
+
+      def core_keyword_accessor(keyword, *args)
+        return schema_core_keywords[keyword] if args.empty?
+
+        schema_core_keywords[keyword] = args.first
       end
     end
 

--- a/lib/ruby_llm/schema.rb
+++ b/lib/ruby_llm/schema.rb
@@ -93,7 +93,7 @@ module RubyLLM
     end
 
     def respond_to_missing?(method_name, include_private = false)
-      %i[string number integer boolean array object any_of one_of all_of none_of null].include?(method_name) || super
+      %i[string number integer boolean array tuple object any_of one_of all_of none_of null].include?(method_name) || super
     end
   end
 end

--- a/lib/ruby_llm/schema/dsl/complex_types.rb
+++ b/lib/ruby_llm/schema/dsl/complex_types.rb
@@ -20,6 +20,14 @@ module RubyLLM
           add_property(name, one_of_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
+        def all_of(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, all_of_schema(description: description, **options, &block), required: required, requires: requires)
+        end
+
+        def none_of(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, none_of_schema(description: description, **options, &block), required: required, requires: requires)
+        end
+
         def optional(name, description: nil, &block)
           any_of(name, description: description) do
             instance_eval(&block)

--- a/lib/ruby_llm/schema/dsl/complex_types.rb
+++ b/lib/ruby_llm/schema/dsl/complex_types.rb
@@ -32,6 +32,10 @@ module RubyLLM
           add_property(name, none_of_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
+        def raw(name, schema, required: true, requires: nil)
+          add_property(name, normalize_raw_schema(schema), required: required, requires: requires)
+        end
+
         def optional(name, description: nil, &block)
           any_of(name, description: description) do
             instance_eval(&block)

--- a/lib/ruby_llm/schema/dsl/complex_types.rb
+++ b/lib/ruby_llm/schema/dsl/complex_types.rb
@@ -12,6 +12,10 @@ module RubyLLM
           add_property(name, array_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
+        def tuple(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, tuple_schema(description: description, **options, &block), required: required, requires: requires)
+        end
+
         def any_of(name, description: nil, required: true, requires: nil, **options, &block)
           add_property(name, any_of_schema(description: description, **options, &block), required: required, requires: requires)
         end

--- a/lib/ruby_llm/schema/dsl/primitive_types.rb
+++ b/lib/ruby_llm/schema/dsl/primitive_types.rb
@@ -4,8 +4,8 @@ module RubyLLM
   class Schema
     module DSL
       module PrimitiveTypes
-        def string(name, description: nil, required: true, requires: nil, **options)
-          add_property(name, string_schema(description: description, **options), required: required, requires: requires)
+        def string(name, description: nil, required: true, requires: nil, **options, &block)
+          add_property(name, string_schema(description: description, **options, &block), required: required, requires: requires)
         end
 
         def number(name, description: nil, required: true, requires: nil, **options)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -5,6 +5,7 @@ module RubyLLM
     module DSL
       module SchemaBuilders
         NOT_GIVEN = Object.new.freeze
+        SchemaBlock = Struct.new(:schemas, :keywords, keyword_init: true)
 
         def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options)
           format = options.delete(:format)
@@ -62,40 +63,19 @@ module RubyLLM
           add_const({type: "null", description: description}.compact, const)
         end
 
-        def object_schema(description: nil, of: nil, reference: nil, &block)
+        def object_schema(description: nil, of: nil, reference: nil, unevaluated_properties: nil, &block)
           if reference
             warn "[DEPRECATION] The `reference` option will be deprecated. Please use `of` instead."
             of = reference
           end
 
-          if of
-            determine_object_reference(of, description)
-          else
-            sub_schema = Class.new(Schema)
-            result = sub_schema.class_eval(&block)
+          schema = of ? determine_object_reference(of, description) : build_object_schema(description, &block)
 
-            # If the block returned a reference and no properties were added, use the reference
-            if result.is_a?(Hash) && result["$ref"] && sub_schema.properties.empty?
-              result.merge(description ? {description: description} : {})
-            # If the block returned a Schema class or instance, convert it to inline schema
-            elsif schema_class?(result) && sub_schema.properties.empty?
-              schema_class_to_inline_schema(result).merge(description ? {description: description} : {})
-            # Block didn't return reference or schema, so we build an inline object schema
-            else
-              schema = {
-                type: "object",
-                properties: sub_schema.properties,
-                required: sub_schema.required_properties,
-                additionalProperties: sub_schema.additional_properties,
-                description: description
-              }.compact
-
-              merge_conditions(schema, sub_schema)
-            end
-          end
+          schema[:unevaluatedProperties] = unevaluated_properties unless unevaluated_properties.nil?
+          schema
         end
 
-        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, &block)
+        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, &block)
           items = determine_array_items(of, &block)
 
           {
@@ -103,44 +83,46 @@ module RubyLLM
             description: description,
             items: items,
             minItems: min_items,
-            maxItems: max_items
+            maxItems: max_items,
+            unevaluatedItems: unevaluated_items
           }.compact
         end
 
         def any_of_schema(description: nil, &block)
-          schemas = collect_schemas_from_block(&block)
+          schema_block = collect_schema_block(&block)
 
           {
             description: description,
-            anyOf: schemas
-          }.compact
+            anyOf: schema_block.schemas
+          }.merge(schema_block.keywords).compact
         end
 
         def one_of_schema(description: nil, &block)
-          schemas = collect_schemas_from_block(&block)
+          schema_block = collect_schema_block(&block)
 
           {
             description: description,
-            oneOf: schemas
-          }.compact
+            oneOf: schema_block.schemas
+          }.merge(schema_block.keywords).compact
         end
 
         def all_of_schema(description: nil, &block)
-          schemas = collect_schemas_from_block(&block)
+          schema_block = collect_schema_block(&block)
 
           {
             description: description,
-            allOf: schemas
-          }.compact
+            allOf: schema_block.schemas
+          }.merge(schema_block.keywords).compact
         end
 
         def none_of_schema(description: nil, &block)
-          schemas = collect_schemas_from_block(&block)
+          schema_block = collect_schema_block(&block)
+          schemas = schema_block.schemas
 
           {
             description: description,
             not: schemas.one? ? schemas.first : {anyOf: schemas}
-          }.compact
+          }.merge(schema_block.keywords).compact
         end
 
         private
@@ -165,6 +147,24 @@ module RubyLLM
           raise InvalidArrayTypeError, "Invalid array type: #{of.inspect}. Must be a primitive type (:string, :number, etc.), a symbol reference, a Schema class, or a Schema instance."
         end
 
+        def build_object_schema(description, &block)
+          sub_schema = Class.new(Schema)
+          result = sub_schema.class_eval(&block)
+
+          return result.merge(description ? {description: description} : {}) if result.is_a?(Hash) && result["$ref"] && sub_schema.properties.empty?
+          return schema_class_to_inline_schema(result).merge(description ? {description: description} : {}) if schema_class?(result) && sub_schema.properties.empty?
+
+          schema = {
+            type: "object",
+            properties: sub_schema.properties,
+            required: sub_schema.required_properties,
+            additionalProperties: sub_schema.additional_properties,
+            description: description
+          }.compact
+
+          merge_conditions(schema, sub_schema)
+        end
+
         def determine_object_reference(of, description = nil)
           result = case of
                    when Symbol
@@ -185,7 +185,11 @@ module RubyLLM
         end
 
         def collect_schemas_from_block(&block)
-          schemas = []
+          collect_schema_block(&block).schemas
+        end
+
+        def collect_schema_block(&block)
+          schema_block = SchemaBlock.new(schemas: [], keywords: {})
           schema_builder = self
 
           context = Object.new
@@ -195,8 +199,16 @@ module RubyLLM
             type_name = schema_method.to_s.sub(/_schema$/, "")
 
             context.define_singleton_method(type_name) do |_name = nil, **options, &blk|
-              schemas << schema_builder.send(schema_method, **options, &blk)
+              schema_block.schemas << schema_builder.send(schema_method, **options, &blk)
             end
+          end
+
+          context.define_singleton_method(:unevaluated_properties) do |value|
+            schema_block.keywords[:unevaluatedProperties] = value
+          end
+
+          context.define_singleton_method(:unevaluated_items) do |value|
+            schema_block.keywords[:unevaluatedItems] = value
           end
 
           # Allow Schema classes to be accessed in the context
@@ -205,7 +217,7 @@ module RubyLLM
           end
 
           context.instance_eval(&block)
-          schemas
+          schema_block
         end
 
         def schema_class_to_inline_schema(schema_class_or_instance)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -63,7 +63,7 @@ module RubyLLM
           add_const({type: "null", description: description}.compact, const)
         end
 
-        def object_schema(description: nil, of: nil, reference: nil, unevaluated_properties: nil, &block)
+        def object_schema(description: nil, of: nil, reference: nil, min_properties: nil, max_properties: nil, unevaluated_properties: nil, &block)
           if reference
             warn "[DEPRECATION] The `reference` option will be deprecated. Please use `of` instead."
             of = reference
@@ -72,6 +72,8 @@ module RubyLLM
           schema = of ? determine_object_reference(of, description) : build_object_schema(description, &block)
 
           schema[:unevaluatedProperties] = unevaluated_properties unless unevaluated_properties.nil?
+          schema[:minProperties] = min_properties unless min_properties.nil?
+          schema[:maxProperties] = max_properties unless max_properties.nil?
           schema
         end
 
@@ -163,6 +165,7 @@ module RubyLLM
           }.compact
 
           merge_conditions(schema, sub_schema)
+          merge_object_keywords(schema, sub_schema)
         end
 
         def determine_object_reference(of, description = nil)
@@ -245,6 +248,7 @@ module RubyLLM
             schema[:description] = description if description
 
             merge_conditions(schema, schema_class)
+            merge_object_keywords(schema, schema_class)
           end
         end
       end

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -16,22 +16,26 @@ module RubyLLM
           }.compact
         end
 
-        def number_schema(description: nil, minimum: nil, maximum: nil, multiple_of: nil)
+        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
           {
             type: "number",
             description: description,
             minimum: minimum,
             maximum: maximum,
+            exclusiveMinimum: greater_than,
+            exclusiveMaximum: less_than,
             multipleOf: multiple_of
           }.compact
         end
 
-        def integer_schema(description: nil, minimum: nil, maximum: nil, multiple_of: nil)
+        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
           {
             type: "integer",
             description: description,
             minimum: minimum,
             maximum: maximum,
+            exclusiveMinimum: greater_than,
+            exclusiveMaximum: less_than,
             multipleOf: multiple_of
           }.compact
         end

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -203,7 +203,7 @@ module RubyLLM
 
           schema = metadata.merge({
             description: description,
-            not: schemas.one? ? schemas.first : {anyOf: schemas}
+            not: schemas.length == 1 ? schemas.first : {anyOf: schemas}
           }.compact)
 
           merge_schema_block_keywords(schema, schema_block)
@@ -238,6 +238,19 @@ module RubyLLM
           return schema unless schema_class.respond_to?(:schema_core_keywords)
 
           schema.merge!(schema_class.schema_core_keywords)
+        end
+
+        def normalize_raw_schema(schema)
+          case schema
+          when Hash
+            schema.each_with_object({}) do |(key, value), normalized|
+              normalized[key.is_a?(Symbol) ? key.to_s : key] = normalize_raw_schema(value)
+            end
+          when Array
+            schema.map { |value| normalize_raw_schema(value) }
+          else
+            schema
+          end
         end
 
         def raise_unknown_options!(type, options)
@@ -331,6 +344,18 @@ module RubyLLM
 
           context.define_singleton_method(:content_schema) do |&blk|
             schema_block.keywords[:contentSchema] = schema_builder.send(:collect_schemas_from_block, &blk).first
+          end
+
+          context.define_singleton_method(:any_schema) do
+            schema_block.schemas << true
+          end
+
+          context.define_singleton_method(:no_schema) do
+            schema_block.schemas << false
+          end
+
+          context.define_singleton_method(:raw) do |schema|
+            schema_block.schemas << schema_builder.send(:normalize_raw_schema, schema)
           end
 
           context.define_singleton_method(:description) do |value|

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -234,6 +234,12 @@ module RubyLLM
           schema.replace(schema_class.schema_metadata.merge(schema))
         end
 
+        def merge_core_keywords(schema, schema_class)
+          return schema unless schema_class.respond_to?(:schema_core_keywords)
+
+          schema.merge!(schema_class.schema_core_keywords)
+        end
+
         def raise_unknown_options!(type, options)
           return if options.empty?
 
@@ -266,6 +272,7 @@ module RubyLLM
           }.compact
 
           merge_schema_metadata(schema, sub_schema)
+          merge_core_keywords(schema, sub_schema)
           merge_conditions(schema, sub_schema)
           merge_object_keywords(schema, sub_schema)
         end
@@ -336,6 +343,12 @@ module RubyLLM
             end
           end
 
+          RubyLLM::Schema::CORE_KEYWORDS.each do |method_name, keyword|
+            context.define_singleton_method(method_name) do |value|
+              schema_block.keywords[keyword] = value
+            end
+          end
+
           # Allow Schema classes to be accessed in the context
           context.define_singleton_method(:const_missing) do |name|
             const_get(name) if const_defined?(name)
@@ -368,6 +381,7 @@ module RubyLLM
                           end
 
             merge_schema_metadata(schema, schema_class)
+            merge_core_keywords(schema, schema_class)
             schema[:description] = description if description
 
             merge_conditions(schema, schema_class)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -15,21 +15,28 @@ module RubyLLM
         }.freeze
         SchemaBlock = Struct.new(:schemas, :keywords, keyword_init: true)
 
-        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options)
+        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options, &block)
           metadata = extract_metadata!(options)
           format = options.delete(:format)
           const = options.delete(:const) { NOT_GIVEN }
+          content_encoding = options.delete(:content_encoding)
+          content_media_type = options.delete(:content_media_type)
           raise_unknown_options!("string", options)
+          schema_block = collect_schema_block(&block) if block_given?
 
-          add_const(metadata.merge({
+          schema = add_const(metadata.merge({
             type: "string",
             enum: enum,
             description: description,
             minLength: min_length,
             maxLength: max_length,
             pattern: pattern,
-            format: format
+            format: format,
+            contentEncoding: content_encoding,
+            contentMediaType: content_media_type
           }.compact), const)
+
+          merge_schema_block_keywords(schema, schema_block)
         end
 
         def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
@@ -313,6 +320,10 @@ module RubyLLM
             schema_block.keywords[:contains] = schema_builder.send(:collect_schemas_from_block, &blk).first
             schema_block.keywords[:minContains] = min unless min.nil?
             schema_block.keywords[:maxContains] = max unless max.nil?
+          end
+
+          context.define_singleton_method(:content_schema) do |&blk|
+            schema_block.keywords[:contentSchema] = schema_builder.send(:collect_schemas_from_block, &blk).first
           end
 
           context.define_singleton_method(:description) do |value|

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -41,12 +41,14 @@ module RubyLLM
 
         def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
           metadata = extract_metadata!(options)
+          enum = options.delete(:enum)
           multiple_of = options.delete(:multiple_of)
           const = options.delete(:const) { NOT_GIVEN }
           raise_unknown_options!("number", options)
 
           add_const(metadata.merge({
             type: "number",
+            enum: enum,
             description: description,
             minimum: minimum,
             maximum: maximum,
@@ -58,12 +60,14 @@ module RubyLLM
 
         def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
           metadata = extract_metadata!(options)
+          enum = options.delete(:enum)
           multiple_of = options.delete(:multiple_of)
           const = options.delete(:const) { NOT_GIVEN }
           raise_unknown_options!("integer", options)
 
           add_const(metadata.merge({
             type: "integer",
+            enum: enum,
             description: description,
             minimum: minimum,
             maximum: maximum,

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -125,6 +125,24 @@ module RubyLLM
           }.compact
         end
 
+        def all_of_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            description: description,
+            allOf: schemas
+          }.compact
+        end
+
+        def none_of_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            description: description,
+            not: schemas.one? ? schemas.first : {anyOf: schemas}
+          }.compact
+        end
+
         private
 
         def add_const(schema, const)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -77,16 +77,33 @@ module RubyLLM
           schema
         end
 
-        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, &block)
-          items = determine_array_items(of, &block)
+        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, unique: nil, &block)
+          schema_block = collect_schema_block(&block) if block_given?
+          items = determine_array_items(of, schema_block)
 
-          {
+          schema = {
             type: "array",
             description: description,
             items: items,
             minItems: min_items,
             maxItems: max_items,
+            uniqueItems: unique,
             unevaluatedItems: unevaluated_items
+          }.compact
+
+          schema.merge!(schema_block.keywords) if schema_block
+          schema
+        end
+
+        def tuple_schema(description: nil, &block)
+          schemas = collect_schemas_from_block(&block)
+
+          {
+            type: "array",
+            description: description,
+            prefixItems: schemas,
+            minItems: schemas.length,
+            maxItems: schemas.length
           }.compact
         end
 
@@ -140,8 +157,9 @@ module RubyLLM
           raise ArgumentError, "unknown #{type} schema option: #{options.keys.first.inspect}"
         end
 
-        def determine_array_items(of, &)
-          return collect_schemas_from_block(&).first if block_given?
+        def determine_array_items(of, schema_block = nil)
+          return schema_block.schemas.first if schema_block&.schemas&.any?
+          return nil if schema_block
           return send("#{of}_schema") if primitive_type?(of)
           return reference(of) if of.is_a?(Symbol)
           return schema_class_to_inline_schema(of) if schema_class?(of)
@@ -212,6 +230,12 @@ module RubyLLM
 
           context.define_singleton_method(:unevaluated_items) do |value|
             schema_block.keywords[:unevaluatedItems] = value
+          end
+
+          context.define_singleton_method(:contains) do |min: nil, max: nil, &blk|
+            schema_block.keywords[:contains] = schema_builder.send(:collect_schemas_from_block, &blk).first
+            schema_block.keywords[:minContains] = min unless min.nil?
+            schema_block.keywords[:maxContains] = max unless max.nil?
           end
 
           # Allow Schema classes to be accessed in the context

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -5,14 +5,23 @@ module RubyLLM
     module DSL
       module SchemaBuilders
         NOT_GIVEN = Object.new.freeze
+        METADATA_OPTIONS = {
+          title: :title,
+          default: :default,
+          examples: :examples,
+          deprecated: :deprecated,
+          read_only: :readOnly,
+          write_only: :writeOnly
+        }.freeze
         SchemaBlock = Struct.new(:schemas, :keywords, keyword_init: true)
 
         def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options)
+          metadata = extract_metadata!(options)
           format = options.delete(:format)
           const = options.delete(:const) { NOT_GIVEN }
           raise_unknown_options!("string", options)
 
-          add_const({
+          add_const(metadata.merge({
             type: "string",
             enum: enum,
             description: description,
@@ -20,15 +29,16 @@ module RubyLLM
             maxLength: max_length,
             pattern: pattern,
             format: format
-          }.compact, const)
+          }.compact), const)
         end
 
         def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
+          metadata = extract_metadata!(options)
           multiple_of = options.delete(:multiple_of)
           const = options.delete(:const) { NOT_GIVEN }
           raise_unknown_options!("number", options)
 
-          add_const({
+          add_const(metadata.merge({
             type: "number",
             description: description,
             minimum: minimum,
@@ -36,15 +46,16 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of
-          }.compact, const)
+          }.compact), const)
         end
 
         def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
+          metadata = extract_metadata!(options)
           multiple_of = options.delete(:multiple_of)
           const = options.delete(:const) { NOT_GIVEN }
           raise_unknown_options!("integer", options)
 
-          add_const({
+          add_const(metadata.merge({
             type: "integer",
             description: description,
             minimum: minimum,
@@ -52,18 +63,32 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of
-          }.compact, const)
+          }.compact), const)
         end
 
-        def boolean_schema(description: nil, const: NOT_GIVEN)
-          add_const({type: "boolean", description: description}.compact, const)
+        def boolean_schema(description: nil, **options)
+          metadata = extract_metadata!(options)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("boolean", options)
+
+          add_const(metadata.merge({type: "boolean", description: description}.compact), const)
         end
 
-        def null_schema(description: nil, const: NOT_GIVEN)
-          add_const({type: "null", description: description}.compact, const)
+        def null_schema(description: nil, **options)
+          metadata = extract_metadata!(options)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("null", options)
+
+          add_const(metadata.merge({type: "null", description: description}.compact), const)
         end
 
-        def object_schema(description: nil, of: nil, reference: nil, min_properties: nil, max_properties: nil, unevaluated_properties: nil, &block)
+        def object_schema(description: nil, of: nil, reference: nil, **options, &block)
+          metadata = extract_metadata!(options)
+          min_properties = options.delete(:min_properties)
+          max_properties = options.delete(:max_properties)
+          unevaluated_properties = options.delete(:unevaluated_properties)
+          raise_unknown_options!("object", options)
+
           if reference
             warn "[DEPRECATION] The `reference` option will be deprecated. Please use `of` instead."
             of = reference
@@ -71,17 +96,25 @@ module RubyLLM
 
           schema = of ? determine_object_reference(of, description) : build_object_schema(description, &block)
 
+          schema.merge!(metadata)
           schema[:unevaluatedProperties] = unevaluated_properties unless unevaluated_properties.nil?
           schema[:minProperties] = min_properties unless min_properties.nil?
           schema[:maxProperties] = max_properties unless max_properties.nil?
           schema
         end
 
-        def array_schema(description: nil, of: nil, min_items: nil, max_items: nil, unevaluated_items: nil, unique: nil, &block)
+        def array_schema(description: nil, of: nil, **options, &block)
+          metadata = extract_metadata!(options)
+          min_items = options.delete(:min_items)
+          max_items = options.delete(:max_items)
+          unevaluated_items = options.delete(:unevaluated_items)
+          unique = options.delete(:unique)
+          raise_unknown_options!("array", options)
+
           schema_block = collect_schema_block(&block) if block_given?
           items = determine_array_items(of, schema_block)
 
-          schema = {
+          schema = metadata.merge({
             type: "array",
             description: description,
             items: items,
@@ -89,59 +122,84 @@ module RubyLLM
             maxItems: max_items,
             uniqueItems: unique,
             unevaluatedItems: unevaluated_items
-          }.compact
+          }.compact)
 
-          schema.merge!(schema_block.keywords) if schema_block
-          schema
+          merge_schema_block_keywords(schema, schema_block)
         end
 
-        def tuple_schema(description: nil, &block)
-          schemas = collect_schemas_from_block(&block)
+        def tuple_schema(description: nil, **options, &block)
+          metadata = extract_metadata!(options)
+          raise_unknown_options!("tuple", options)
 
-          {
+          schema_block = collect_schema_block(&block)
+          schemas = schema_block.schemas
+
+          schema = metadata.merge({
             type: "array",
             description: description,
             prefixItems: schemas,
             minItems: schemas.length,
             maxItems: schemas.length
-          }.compact
+          }.compact)
+
+          merge_schema_block_keywords(schema, schema_block)
         end
 
-        def any_of_schema(description: nil, &block)
+        def any_of_schema(description: nil, **options, &block)
+          metadata = extract_metadata!(options)
+          raise_unknown_options!("any_of", options)
+
           schema_block = collect_schema_block(&block)
 
-          {
+          schema = metadata.merge({
             description: description,
             anyOf: schema_block.schemas
-          }.merge(schema_block.keywords).compact
+          }.compact)
+
+          merge_schema_block_keywords(schema, schema_block)
         end
 
-        def one_of_schema(description: nil, &block)
+        def one_of_schema(description: nil, **options, &block)
+          metadata = extract_metadata!(options)
+          raise_unknown_options!("one_of", options)
+
           schema_block = collect_schema_block(&block)
 
-          {
+          schema = metadata.merge({
             description: description,
             oneOf: schema_block.schemas
-          }.merge(schema_block.keywords).compact
+          }.compact)
+
+          merge_schema_block_keywords(schema, schema_block)
         end
 
-        def all_of_schema(description: nil, &block)
+        def all_of_schema(description: nil, **options, &block)
+          metadata = extract_metadata!(options)
+          raise_unknown_options!("all_of", options)
+
           schema_block = collect_schema_block(&block)
 
-          {
+          schema = metadata.merge({
             description: description,
             allOf: schema_block.schemas
-          }.merge(schema_block.keywords).compact
+          }.compact)
+
+          merge_schema_block_keywords(schema, schema_block)
         end
 
-        def none_of_schema(description: nil, &block)
+        def none_of_schema(description: nil, **options, &block)
+          metadata = extract_metadata!(options)
+          raise_unknown_options!("none_of", options)
+
           schema_block = collect_schema_block(&block)
           schemas = schema_block.schemas
 
-          {
+          schema = metadata.merge({
             description: description,
             not: schemas.one? ? schemas.first : {anyOf: schemas}
-          }.merge(schema_block.keywords).compact
+          }.compact)
+
+          merge_schema_block_keywords(schema, schema_block)
         end
 
         private
@@ -149,6 +207,24 @@ module RubyLLM
         def add_const(schema, const)
           schema[:const] = const unless const.equal?(NOT_GIVEN)
           schema
+        end
+
+        def extract_metadata!(options)
+          METADATA_OPTIONS.each_with_object({}) do |(option, keyword), metadata|
+            metadata[keyword] = options.delete(option) if options.key?(option)
+          end
+        end
+
+        def merge_schema_block_keywords(schema, schema_block)
+          return schema unless schema_block
+
+          schema.replace(schema_block.keywords.merge(schema))
+        end
+
+        def merge_schema_metadata(schema, schema_class)
+          return schema unless schema_class.respond_to?(:schema_metadata)
+
+          schema.replace(schema_class.schema_metadata.merge(schema))
         end
 
         def raise_unknown_options!(type, options)
@@ -182,6 +258,7 @@ module RubyLLM
             description: description
           }.compact
 
+          merge_schema_metadata(schema, sub_schema)
           merge_conditions(schema, sub_schema)
           merge_object_keywords(schema, sub_schema)
         end
@@ -238,6 +315,16 @@ module RubyLLM
             schema_block.keywords[:maxContains] = max unless max.nil?
           end
 
+          context.define_singleton_method(:description) do |value|
+            schema_block.keywords[:description] = value
+          end
+
+          METADATA_OPTIONS.each do |method_name, keyword|
+            context.define_singleton_method(method_name) do |value|
+              schema_block.keywords[keyword] = value
+            end
+          end
+
           # Allow Schema classes to be accessed in the context
           context.define_singleton_method(:const_missing) do |name|
             const_get(name) if const_defined?(name)
@@ -269,6 +356,7 @@ module RubyLLM
                             schema_class_or_instance.instance_variable_get(:@description) || schema_class.description
                           end
 
+            merge_schema_metadata(schema, schema_class)
             schema[:description] = description if description
 
             merge_conditions(schema, schema_class)

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -4,8 +4,14 @@ module RubyLLM
   class Schema
     module DSL
       module SchemaBuilders
-        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, format: nil)
-          {
+        NOT_GIVEN = Object.new.freeze
+
+        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, **options)
+          format = options.delete(:format)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("string", options)
+
+          add_const({
             type: "string",
             enum: enum,
             description: description,
@@ -13,11 +19,15 @@ module RubyLLM
             maxLength: max_length,
             pattern: pattern,
             format: format
-          }.compact
+          }.compact, const)
         end
 
-        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
-          {
+        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
+          multiple_of = options.delete(:multiple_of)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("number", options)
+
+          add_const({
             type: "number",
             description: description,
             minimum: minimum,
@@ -25,11 +35,15 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of
-          }.compact
+          }.compact, const)
         end
 
-        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil)
-          {
+        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, **options)
+          multiple_of = options.delete(:multiple_of)
+          const = options.delete(:const) { NOT_GIVEN }
+          raise_unknown_options!("integer", options)
+
+          add_const({
             type: "integer",
             description: description,
             minimum: minimum,
@@ -37,15 +51,15 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of
-          }.compact
+          }.compact, const)
         end
 
-        def boolean_schema(description: nil)
-          {type: "boolean", description: description}.compact
+        def boolean_schema(description: nil, const: NOT_GIVEN)
+          add_const({type: "boolean", description: description}.compact, const)
         end
 
-        def null_schema(description: nil)
-          {type: "null", description: description}.compact
+        def null_schema(description: nil, const: NOT_GIVEN)
+          add_const({type: "null", description: description}.compact, const)
         end
 
         def object_schema(description: nil, of: nil, reference: nil, &block)
@@ -112,6 +126,17 @@ module RubyLLM
         end
 
         private
+
+        def add_const(schema, const)
+          schema[:const] = const unless const.equal?(NOT_GIVEN)
+          schema
+        end
+
+        def raise_unknown_options!(type, options)
+          return if options.empty?
+
+          raise ArgumentError, "unknown #{type} schema option: #{options.keys.first.inspect}"
+        end
 
         def determine_array_items(of, &)
           return collect_schemas_from_block(&).first if block_given?

--- a/lib/ruby_llm/schema/dsl/utilities.rb
+++ b/lib/ruby_llm/schema/dsl/utilities.rb
@@ -16,9 +16,23 @@ module RubyLLM
             additionalProperties: sub_schema.additional_properties
           }
 
+          merge_object_keywords(schema, sub_schema)
           merge_conditions(schema, sub_schema)
 
           definitions[name] = schema
+        end
+
+        def object_keywords
+          @object_keywords ||= {}
+        end
+
+        def keys_matching(pattern, &block)
+          object_keywords[:patternProperties] ||= {}
+          object_keywords[:patternProperties][pattern_source(pattern)] = collect_schemas_from_block(&block).first
+        end
+
+        def keys(&block)
+          object_keywords[:propertyNames] = collect_schemas_from_block(&block).first
         end
 
         def reference(schema_name)
@@ -56,6 +70,16 @@ module RubyLLM
 
         def schema_class?(type)
           (type.is_a?(Class) && type < Schema) || type.is_a?(Schema)
+        end
+
+        def merge_object_keywords(schema, schema_class)
+          return schema unless schema_class.respond_to?(:object_keywords)
+
+          schema.merge!(schema_class.object_keywords)
+        end
+
+        def pattern_source(pattern)
+          pattern.is_a?(Regexp) ? pattern.source : pattern.to_s
         end
       end
     end

--- a/lib/ruby_llm/schema/dsl/utilities.rb
+++ b/lib/ruby_llm/schema/dsl/utilities.rb
@@ -16,6 +16,7 @@ module RubyLLM
             additionalProperties: sub_schema.additional_properties
           }
 
+          merge_schema_metadata(schema, sub_schema)
           merge_object_keywords(schema, sub_schema)
           merge_conditions(schema, sub_schema)
 

--- a/lib/ruby_llm/schema/dsl/utilities.rb
+++ b/lib/ruby_llm/schema/dsl/utilities.rb
@@ -17,6 +17,7 @@ module RubyLLM
           }
 
           merge_schema_metadata(schema, sub_schema)
+          merge_core_keywords(schema, sub_schema)
           merge_object_keywords(schema, sub_schema)
           merge_conditions(schema, sub_schema)
 

--- a/lib/ruby_llm/schema/json_output.rb
+++ b/lib/ruby_llm/schema/json_output.rb
@@ -19,6 +19,7 @@ module RubyLLM
         schema_hash["$defs"] = self.class.definitions unless self.class.definitions.empty?
 
         self.class.send(:merge_conditions, schema_hash, self.class)
+        self.class.send(:merge_core_keywords, schema_hash, self.class)
 
         {
           name: @name,

--- a/spec/ruby_llm/schema/properties/all_of_spec.rb
+++ b/spec/ruby_llm/schema/properties/all_of_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "allOf properties" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports all_of with mixed schemas" do
+    schema_class.all_of :payload do
+      object do
+        string :name
+      end
+
+      object do
+        integer :age
+      end
+    end
+
+    all_of_schemas = schema_class.properties[:payload][:allOf]
+
+    expect(all_of_schemas.length).to eq(2)
+    expect(all_of_schemas[0][:properties][:name]).to eq({type: "string"})
+    expect(all_of_schemas[1][:properties][:age]).to eq({type: "integer"})
+  end
+
+  it "supports arrays of allOf types" do
+    schema_class.array :items do
+      all_of :value do
+        object do
+          string :name
+        end
+
+        object do
+          integer :age
+        end
+      end
+    end
+
+    all_of_schemas = schema_class.properties[:items][:items][:allOf]
+
+    expect(all_of_schemas.length).to eq(2)
+    expect(all_of_schemas.map { |schema| schema[:type] }).to eq(%w[object object])
+  end
+end

--- a/spec/ruby_llm/schema/properties/array_validation_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/array_validation_keywords_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "array validation keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports uniqueItems with homogeneous arrays" do
+    schema_class.array :tags, of: :string, unique: true
+
+    expect(schema_class.properties[:tags]).to eq({
+      type: "array",
+      items: {type: "string"},
+      uniqueItems: true
+    })
+  end
+
+  it "supports tuple schemas with prefixItems" do
+    schema_class.tuple :coordinates do
+      number description: "Latitude"
+      number description: "Longitude"
+    end
+
+    expect(schema_class.properties[:coordinates]).to eq({
+      type: "array",
+      prefixItems: [
+        {type: "number", description: "Latitude"},
+        {type: "number", description: "Longitude"}
+      ],
+      minItems: 2,
+      maxItems: 2
+    })
+  end
+
+  it "supports tuple schemas with object entries" do
+    schema_class.tuple :event do
+      string description: "Event name"
+      integer description: "Unix timestamp"
+      object description: "Payload" do
+        string :id
+        string :source
+      end
+    end
+
+    event_schema = schema_class.properties[:event]
+
+    expect(event_schema[:prefixItems].length).to eq(3)
+    expect(event_schema[:prefixItems][2][:properties][:id]).to eq({type: "string"})
+    expect(event_schema[:minItems]).to eq(3)
+    expect(event_schema[:maxItems]).to eq(3)
+  end
+
+  it "supports contains with minContains and maxContains" do
+    schema_class.array :scores do
+      contains min: 1, max: 3 do
+        integer minimum: 10
+      end
+    end
+
+    expect(schema_class.properties[:scores]).to eq({
+      type: "array",
+      contains: {type: "integer", minimum: 10},
+      minContains: 1,
+      maxContains: 3
+    })
+  end
+
+  it "keeps existing homogeneous item behavior" do
+    schema_class.array :items, of: :integer
+
+    expect(schema_class.properties[:items]).to eq({
+      type: "array",
+      items: {type: "integer"}
+    })
+  end
+end

--- a/spec/ruby_llm/schema/properties/boolean_and_raw_schemas_spec.rb
+++ b/spec/ruby_llm/schema/properties/boolean_and_raw_schemas_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "boolean and raw schemas" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports true schemas inside composition" do
+    schema_class.any_of :value do
+      any_schema
+      string
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      anyOf: [
+        true,
+        {type: "string"}
+      ]
+    })
+  end
+
+  it "supports false schemas inside composition" do
+    schema_class.none_of :value do
+      no_schema
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      not: false
+    })
+  end
+
+  it "supports raw schema properties" do
+    schema_class.raw :role, {
+      "type" => "string",
+      "const" => "admin"
+    }
+
+    expect(schema_class.properties[:role]).to eq({
+      "type" => "string",
+      "const" => "admin"
+    })
+  end
+
+  it "normalizes symbol keys inside raw schemas" do
+    schema_class.raw :payload, {
+      type: "object",
+      properties: {
+        role: {const: "admin"}
+      }
+    }
+
+    expect(schema_class.properties[:payload]).to eq({
+      "type" => "object",
+      "properties" => {
+        "role" => {"const" => "admin"}
+      }
+    })
+  end
+
+  it "supports anonymous raw schemas inside composition" do
+    schema_class.any_of :value do
+      raw type: "string", const: "admin"
+      integer
+    end
+
+    expect(schema_class.properties[:value]).to eq({
+      anyOf: [
+        {"type" => "string", "const" => "admin"},
+        {type: "integer"}
+      ]
+    })
+  end
+end

--- a/spec/ruby_llm/schema/properties/booleans_spec.rb
+++ b/spec/ruby_llm/schema/properties/booleans_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe RubyLLM::Schema, "boolean properties" do
     properties = schema_class.properties
     expect(properties[:enabled]).to eq({type: "boolean", description: "Enabled field"})
   end
+
+  it "supports boolean const values" do
+    schema_class.boolean :enabled, const: false
+
+    properties = schema_class.properties
+    expect(properties[:enabled]).to eq({type: "boolean", const: false})
+  end
 end

--- a/spec/ruby_llm/schema/properties/content_annotations_spec.rb
+++ b/spec/ruby_llm/schema/properties/content_annotations_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "content annotations" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports contentEncoding and contentMediaType keywords" do
+    schema_class.string :payload,
+                        content_encoding: "base64",
+                        content_media_type: "application/json"
+
+    expect(schema_class.properties[:payload]).to eq({
+      type: "string",
+      contentEncoding: "base64",
+      contentMediaType: "application/json"
+    })
+  end
+
+  it "supports nested contentSchema blocks" do
+    schema_class.string :payload,
+                        content_encoding: "base64",
+                        content_media_type: "application/json" do
+      content_schema do
+        object do
+          title "Payload"
+          description "Decoded JSON payload"
+
+          string :name
+        end
+      end
+    end
+
+    payload_schema = schema_class.properties[:payload]
+
+    expect(payload_schema[:contentSchema]).to include(
+      type: "object",
+      title: "Payload",
+      description: "Decoded JSON payload"
+    )
+    expect(payload_schema[:contentSchema][:properties][:name]).to eq({type: "string"})
+  end
+
+  it "supports metadata on the encoded string node" do
+    schema_class.string :payload, title: "Encoded payload" do
+      content_schema do
+        object do
+          string :name
+        end
+      end
+    end
+
+    payload_schema = schema_class.properties[:payload]
+
+    expect(payload_schema[:title]).to eq("Encoded payload")
+    expect(payload_schema[:contentSchema][:properties][:name]).to eq({type: "string"})
+  end
+end

--- a/spec/ruby_llm/schema/properties/core_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/core_keywords_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "core keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports root schema core keywords" do
+    schema_class.id "https://example.com/schemas/person"
+    schema_class.anchor "person"
+    schema_class.comment "Internal note"
+    schema_class.dynamic_anchor "node"
+    schema_class.dynamic_ref "#node"
+    schema_class.vocabulary "https://json-schema.org/draft/2020-12/vocab/core" => true
+
+    schema = schema_class.new.to_json_schema[:schema]
+
+    expect(schema).to include(
+      "$id" => "https://example.com/schemas/person",
+      "$anchor" => "person",
+      "$comment" => "Internal note",
+      "$dynamicAnchor" => "node",
+      "$dynamicRef" => "#node",
+      "$vocabulary" => {"https://json-schema.org/draft/2020-12/vocab/core" => true}
+    )
+  end
+
+  it "supports core keywords inside definitions" do
+    schema_class.define :address do
+      anchor "address"
+      comment "Reusable address schema"
+
+      string :street
+    end
+
+    definition = schema_class.definitions[:address]
+
+    expect(definition["$anchor"]).to eq("address")
+    expect(definition["$comment"]).to eq("Reusable address schema")
+  end
+
+  it "supports core keywords inside nested object schemas" do
+    schema_class.object :node do
+      dynamic_anchor "node"
+
+      string :value
+    end
+
+    node_schema = schema_class.properties[:node]
+
+    expect(node_schema["$dynamicAnchor"]).to eq("node")
+    expect(node_schema[:properties][:value]).to eq({type: "string"})
+  end
+
+  it "supports core keywords on composition schemas" do
+    schema_class.any_of :identifier do
+      comment "Accepted identifier formats"
+
+      string
+      integer
+    end
+
+    identifier_schema = schema_class.properties[:identifier]
+
+    expect(identifier_schema["$comment"]).to eq("Accepted identifier formats")
+    expect(identifier_schema[:anyOf].map { |schema| schema[:type] }).to eq(%w[string integer])
+  end
+end

--- a/spec/ruby_llm/schema/properties/metadata_annotations_spec.rb
+++ b/spec/ruby_llm/schema/properties/metadata_annotations_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "metadata annotations" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports metadata keyword arguments on primitive schemas" do
+    schema_class.string :email,
+                        title: "Email address",
+                        description: "Primary contact email",
+                        default: "user@example.com",
+                        examples: ["alice@example.com"],
+                        deprecated: false,
+                        read_only: false,
+                        write_only: true
+
+    expect(schema_class.properties[:email]).to eq({
+      type: "string",
+      title: "Email address",
+      description: "Primary contact email",
+      default: "user@example.com",
+      examples: ["alice@example.com"],
+      deprecated: false,
+      readOnly: false,
+      writeOnly: true
+    })
+  end
+
+  it "supports block annotations on object schemas" do
+    schema_class.object :account do
+      title "Account"
+      description "Billing account metadata"
+      default({status: "active"})
+      examples [{id: "acct_123", status: "active"}]
+      deprecated false
+      read_only false
+      write_only false
+
+      string :id
+      string :status
+    end
+
+    account_schema = schema_class.properties[:account]
+
+    expect(account_schema).to include(
+      title: "Account",
+      description: "Billing account metadata",
+      default: {status: "active"},
+      examples: [{id: "acct_123", status: "active"}],
+      deprecated: false,
+      readOnly: false,
+      writeOnly: false
+    )
+    expect(account_schema[:properties][:id]).to eq({type: "string"})
+  end
+
+  it "keeps keyword annotations ahead of block annotations" do
+    schema_class.object :account, title: "Keyword title", description: "Keyword description" do
+      title "Block title"
+      description "Block description"
+    end
+
+    account_schema = schema_class.properties[:account]
+
+    expect(account_schema[:title]).to eq("Keyword title")
+    expect(account_schema[:description]).to eq("Keyword description")
+  end
+
+  it "supports current-node annotations on arrays and array items" do
+    schema_class.array :events do
+      description "Chronological event list"
+
+      object do
+        description "Single event payload"
+
+        string :type
+      end
+    end
+
+    events_schema = schema_class.properties[:events]
+
+    expect(events_schema[:description]).to eq("Chronological event list")
+    expect(events_schema[:items][:description]).to eq("Single event payload")
+    expect(events_schema[:items][:properties][:type]).to eq({type: "string"})
+  end
+
+  it "supports current-node annotations on composition schemas" do
+    schema_class.any_of :identifier do
+      description "Accepted user identifier formats"
+
+      string description: "Username"
+      integer description: "Numeric user ID"
+    end
+
+    identifier_schema = schema_class.properties[:identifier]
+
+    expect(identifier_schema[:description]).to eq("Accepted user identifier formats")
+    expect(identifier_schema[:anyOf]).to eq(
+      [
+        {type: "string", description: "Username"},
+        {type: "integer", description: "Numeric user ID"}
+      ]
+    )
+  end
+
+  it "supports annotations inside reusable definitions" do
+    schema_class.define :address do
+      title "Address"
+      description "Reusable postal address schema"
+
+      string :street
+      string :city
+    end
+
+    definition = schema_class.definitions[:address]
+
+    expect(definition[:title]).to eq("Address")
+    expect(definition[:description]).to eq("Reusable postal address schema")
+    expect(definition[:properties][:street]).to eq({type: "string"})
+  end
+end

--- a/spec/ruby_llm/schema/properties/none_of_spec.rb
+++ b/spec/ruby_llm/schema/properties/none_of_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "not properties" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports none_of with a single schema" do
+    schema_class.none_of :status do
+      string enum: ["forbidden"]
+    end
+
+    properties = schema_class.properties
+
+    expect(properties[:status]).to eq({
+      not: {type: "string", enum: ["forbidden"]}
+    })
+  end
+
+  it "wraps multiple none_of schemas in anyOf" do
+    schema_class.none_of :status do
+      string enum: ["forbidden"]
+      integer
+    end
+
+    properties = schema_class.properties
+
+    expect(properties[:status]).to eq({
+      not: {
+        anyOf: [
+          {type: "string", enum: ["forbidden"]},
+          {type: "integer"}
+        ]
+      }
+    })
+  end
+
+  it "supports arrays of not schemas" do
+    schema_class.array :items do
+      none_of :value do
+        null
+      end
+    end
+
+    item_schema = schema_class.properties[:items][:items]
+
+    expect(item_schema).to eq({not: {type: "null"}})
+  end
+end

--- a/spec/ruby_llm/schema/properties/null_spec.rb
+++ b/spec/ruby_llm/schema/properties/null_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe RubyLLM::Schema, "null properties" do
     properties = schema_class.properties
     expect(properties[:placeholder]).to eq({type: "null", description: "Null field"})
   end
+
+  it "supports null const values" do
+    schema_class.null :deleted_at, const: nil
+
+    properties = schema_class.properties
+    expect(properties[:deleted_at]).to eq({type: "null", const: nil})
+  end
 end

--- a/spec/ruby_llm/schema/properties/numbers_spec.rb
+++ b/spec/ruby_llm/schema/properties/numbers_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
     })
   end
 
+  it "supports number const values" do
+    schema_class.number :version, const: 1.5
+
+    properties = schema_class.properties
+    expect(properties[:version]).to eq({type: "number", const: 1.5})
+  end
+
   it "supports number type with description" do
     schema_class.number :price, description: "Price field"
 
@@ -52,5 +59,12 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
       exclusiveMinimum: 17,
       exclusiveMaximum: 66
     })
+  end
+
+  it "supports integer const values" do
+    schema_class.integer :version, const: 1
+
+    properties = schema_class.properties
+    expect(properties[:version]).to eq({type: "integer", const: 1})
   end
 end

--- a/spec/ruby_llm/schema/properties/numbers_spec.rb
+++ b/spec/ruby_llm/schema/properties/numbers_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
     })
   end
 
+  it "supports exclusive number boundaries" do
+    schema_class.number :score, greater_than: 0, less_than: 100
+
+    properties = schema_class.properties
+    expect(properties[:score]).to eq({
+      type: "number",
+      exclusiveMinimum: 0,
+      exclusiveMaximum: 100
+    })
+  end
+
   it "supports number type with description" do
     schema_class.number :price, description: "Price field"
 
@@ -30,5 +41,16 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
 
     properties = schema_class.properties
     expect(properties[:count]).to eq({type: "integer", description: "Count value"})
+  end
+
+  it "supports exclusive integer boundaries" do
+    schema_class.integer :age, greater_than: 17, less_than: 66
+
+    properties = schema_class.properties
+    expect(properties[:age]).to eq({
+      type: "integer",
+      exclusiveMinimum: 17,
+      exclusiveMaximum: 66
+    })
   end
 end

--- a/spec/ruby_llm/schema/properties/numbers_spec.rb
+++ b/spec/ruby_llm/schema/properties/numbers_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
     expect(properties[:version]).to eq({type: "number", const: 1.5})
   end
 
+  it "supports number enum values" do
+    schema_class.number :rating, enum: [1.5, 2.5, 3.5]
+
+    properties = schema_class.properties
+    expect(properties[:rating]).to eq({type: "number", enum: [1.5, 2.5, 3.5]})
+  end
+
   it "supports number type with description" do
     schema_class.number :price, description: "Price field"
 
@@ -66,5 +73,12 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
 
     properties = schema_class.properties
     expect(properties[:version]).to eq({type: "integer", const: 1})
+  end
+
+  it "supports integer enum values" do
+    schema_class.integer :level, enum: [0, 1, 2]
+
+    properties = schema_class.properties
+    expect(properties[:level]).to eq({type: "integer", enum: [0, 1, 2]})
   end
 end

--- a/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "object validation keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports object property count constraints" do
+    schema_class.object :metadata, min_properties: 1, max_properties: 5 do
+      string :name
+    end
+
+    metadata_schema = schema_class.properties[:metadata]
+
+    expect(metadata_schema[:minProperties]).to eq(1)
+    expect(metadata_schema[:maxProperties]).to eq(5)
+  end
+
+  it "supports patternProperties with keys_matching" do
+    schema_class.object :metadata do
+      keys_matching(/^x-/) do
+        string
+      end
+
+      keys_matching(/^count_/) do
+        integer minimum: 0
+      end
+    end
+
+    expect(schema_class.properties[:metadata][:patternProperties]).to eq({
+      "^x-" => {type: "string"},
+      "^count_" => {type: "integer", minimum: 0}
+    })
+  end
+
+  it "supports propertyNames with keys" do
+    schema_class.object :metadata do
+      keys do
+        string pattern: "^[a-z_]+$"
+      end
+    end
+
+    expect(schema_class.properties[:metadata][:propertyNames]).to eq({
+      type: "string",
+      pattern: "^[a-z_]+$"
+    })
+  end
+
+  it "includes object validation keywords in definitions" do
+    schema_class.define :metadata do
+      keys_matching(/^x-/) do
+        string
+      end
+
+      keys do
+        string pattern: "^[a-z_]+$"
+      end
+    end
+
+    definition = schema_class.definitions[:metadata]
+
+    expect(definition[:patternProperties]).to eq({"^x-" => {type: "string"}})
+    expect(definition[:propertyNames]).to eq({type: "string", pattern: "^[a-z_]+$"})
+  end
+
+  it "includes object validation keywords when embedding schema classes" do
+    metadata_schema = Class.new(described_class) do
+      keys_matching(/^x-/) do
+        string
+      end
+    end
+
+    schema_class.object :metadata, of: metadata_schema
+
+    expect(schema_class.properties[:metadata][:patternProperties]).to eq({
+      "^x-" => {type: "string"}
+    })
+  end
+end

--- a/spec/ruby_llm/schema/properties/strings_spec.rb
+++ b/spec/ruby_llm/schema/properties/strings_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe RubyLLM::Schema, "string properties" do
     })
   end
 
+  it "supports string const values" do
+    schema_class.string :role, const: "admin"
+
+    properties = schema_class.properties
+    expect(properties[:role]).to eq({type: "string", const: "admin"})
+  end
+
   it "supports string type with additional options" do
     schema_class.string :email, format: "email", min_length: 5, max_length: 100, pattern: "\\S+@\\S+", description: "Email field"
 

--- a/spec/ruby_llm/schema/properties/unevaluated_spec.rb
+++ b/spec/ruby_llm/schema/properties/unevaluated_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "unevaluated keywords" do
+  let(:schema_class) { Class.new(described_class) }
+
+  it "supports unevaluatedProperties on composition schemas" do
+    schema_class.all_of :person do
+      object do
+        string :name
+      end
+
+      object do
+        integer :age
+      end
+
+      unevaluated_properties false
+    end
+
+    person_schema = schema_class.properties[:person]
+
+    expect(person_schema[:allOf].length).to eq(2)
+    expect(person_schema[:unevaluatedProperties]).to be(false)
+  end
+
+  it "supports unevaluatedProperties on referenced object schemas" do
+    schema_class.define :person do
+      string :name
+    end
+
+    schema_class.object :person, of: :person, unevaluated_properties: false
+
+    expect(schema_class.properties[:person]).to eq({
+      "$ref" => "#/$defs/person",
+      unevaluatedProperties: false
+    })
+  end
+
+  it "supports unevaluatedProperties on inline object schemas" do
+    schema_class.object :metadata, unevaluated_properties: false do
+      string :name
+    end
+
+    metadata_schema = schema_class.properties[:metadata]
+
+    expect(metadata_schema[:properties][:name]).to eq({type: "string"})
+    expect(metadata_schema[:unevaluatedProperties]).to be(false)
+  end
+
+  it "supports unevaluatedItems on array schemas" do
+    schema_class.array :values, of: :integer, unevaluated_items: false
+
+    expect(schema_class.properties[:values]).to eq({
+      type: "array",
+      items: {type: "integer"},
+      unevaluatedItems: false
+    })
+  end
+end


### PR DESCRIPTION
Closes #30

## Summary
- Add `enum:` support to number schemas
- Add `enum:` support to integer schemas
- Cover numeric enum output with focused specs

## Verification
- `bundle exec rake`