### PR TITLE
Decide Draft 2020-12 output contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,71 +604,43 @@ schema = CompanySchema.new
 schema.to_json_schema
 # =>
 # {
-#    "name":"CompanySchema",
-#    "description":"nil",
-#    "schema":{
-#       "type":"object",
-#       "properties":{
-#          "ceo":{
+#    "$schema":"https://json-schema.org/draft/2020-12/schema",
+#    "title":"CompanySchema",
+#    "type":"object",
+#    "properties":{
+#       "ceo":{
+#          "type":"object",
+#          "properties":{
+#             "name":{"type":"string"},
+#             "age":{"type":"integer"}
+#          },
+#          "required":["name","age"],
+#          "additionalProperties":false
+#       },
+#       "employees":{
+#          "type":"array",
+#          "items":{
 #             "type":"object",
 #             "properties":{
-#                "name":{
-#                   "type":"string"
-#                },
-#                "age":{
-#                   "type":"integer"
-#                }
+#                "name":{"type":"string"},
+#                "age":{"type":"integer"}
 #             },
-#             "required":[
-#                :"name",
-#                :"age"
-#             ],
-#             "additionalProperties":false
-#          },
-#          "employees":{
-#             "type":"array",
-#             "items":{
-#                "type":"object",
-#                "properties":{
-#                   "name":{
-#                      "type":"string"
-#                   },
-#                   "age":{
-#                      "type":"integer"
-#                   }
-#                },
-#                "required":[
-#                   :"name",
-#                   :"age"
-#                ],
-#                "additionalProperties":false
-#             }
-#          },
-#          "founder":{
-#             "type":"object",
-#             "properties":{
-#                "name":{
-#                   "type":"string"
-#                },
-#                "age":{
-#                   "type":"integer"
-#                }
-#             },
-#             "required":[
-#                :"name",
-#                :"age"
-#             ],
+#             "required":["name","age"],
 #             "additionalProperties":false
 #          }
 #       },
-#       "required":[
-#          :"ceo",
-#          :"employees",
-#          :"founder"
-#       ],
-#       "additionalProperties":false,
-#       "strict":true
-#    }
+#       "founder":{
+#          "type":"object",
+#          "properties":{
+#             "name":{"type":"string"},
+#             "age":{"type":"integer"}
+#          },
+#          "required":["name","age"],
+#          "additionalProperties":false
+#       }
+#    },
+#    "required":["ceo","employees","founder"],
+#    "additionalProperties":false
 # }
 ```
 
@@ -733,9 +705,31 @@ Conditions propagate through nested schemas via `of:`.
 
 ## JSON Output
 
+`to_json_schema` returns a Draft 2020-12 JSON Schema document with string keys, ready to hand to any JSON Schema validator.
+
 ```ruby
 schema = PersonSchema.new
 schema.to_json_schema
+# => {
+#   "$schema" => "https://json-schema.org/draft/2020-12/schema",
+#   "title" => "PersonSchema",
+#   "type" => "object",
+#   "properties" => { ... },
+#   "required" => [...],
+#   "additionalProperties" => false
+# }
+
+puts schema.to_json  # Pretty JSON string of the same document
+```
+
+The schema name maps to `title`. Provider-only keys such as `strict` are not part of the document.
+
+### Migrating from the provider envelope
+
+`to_json_schema` used to return a RubyLLM/provider envelope. That envelope now lives under `to_ruby_llm_schema`, unchanged:
+
+```ruby
+schema.to_ruby_llm_schema
 # => {
 #   name: "PersonSchema",
 #   description: nil,
@@ -747,9 +741,9 @@ schema.to_json_schema
 #     strict: true
 #   }
 # }
-
-puts schema.to_json  # Pretty JSON string
 ```
+
+If you pass schemas to RubyLLM or another provider that expects the envelope, rename your `to_json_schema` calls to `to_ruby_llm_schema`. If you were reaching into `[:schema]` to get at the document, use `to_json_schema` and drop the digging — but note its keys are strings, not symbols.
 
 ## License
 

--- a/lib/ruby_llm/schema/json_output.rb
+++ b/lib/ruby_llm/schema/json_output.rb
@@ -3,27 +3,34 @@
 module RubyLLM
   class Schema
     module JsonOutput
+      DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
+
+      # A Draft 2020-12 JSON Schema document, string-keyed and ready for any JSON Schema validator
       def to_json_schema
         validate! # Validate schema before generating JSON
 
-        schema_hash = {
-          type: "object",
-          properties: self.class.properties,
-          required: self.class.required_properties,
-          additionalProperties: self.class.additional_properties
-        }
+        document = schema_body
+        class_description = document.delete(:description)
+        header = {
+          "$schema" => DRAFT_2020_12,
+          title: document.delete(:title) || @name,
+          description: @description || class_description
+        }.compact
 
-        schema_hash[:strict] = self.class.strict unless self.class.strict.nil?
+        json_compatible(resolve_runtime_values(header.merge(document)))
+      end
 
-        # Only include $defs if there are definitions
-        schema_hash["$defs"] = self.class.definitions unless self.class.definitions.empty?
+      # The RubyLLM provider envelope. Superseded by to_json_schema; kept for the transition.
+      def to_ruby_llm_schema
+        validate! # Validate schema before generating JSON
 
-        self.class.send(:merge_schema_keywords, schema_hash, self.class)
+        schema = resolve_runtime_values(schema_body)
+        schema[:strict] = self.class.strict unless self.class.strict.nil?
 
         {
           name: @name,
           description: resolve_runtime_values(@description || self.class.description),
-          schema: resolve_runtime_values(schema_hash)
+          schema: schema
         }
       end
 
@@ -33,6 +40,36 @@ module RubyLLM
       end
 
       private
+
+      def schema_body
+        schema_hash = {
+          type: "object",
+          properties: self.class.properties,
+          required: self.class.required_properties,
+          additionalProperties: self.class.additional_properties
+        }
+
+        # Only include $defs if there are definitions
+        schema_hash["$defs"] = self.class.definitions unless self.class.definitions.empty?
+
+        self.class.send(:merge_schema_keywords, schema_hash, self.class)
+
+        schema_hash
+      end
+
+      # JSON Schema documents are string-keyed. Symbols survive a Ruby comparison but not a JSON round trip.
+      def json_compatible(value)
+        case value
+        when Hash
+          value.to_h { |key, nested_value| [key.to_s, json_compatible(nested_value)] }
+        when Array
+          value.map { |nested_value| json_compatible(nested_value) }
+        when Symbol
+          value.to_s
+        else
+          value
+        end
+      end
 
       # Values declared as procs are resolved here, so one schema class can render differently per instance
       def resolve_runtime_values(value)

--- a/spec/ruby_llm/schema/entry_points/class_inheritance_spec.rb
+++ b/spec/ruby_llm/schema/entry_points/class_inheritance_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
 
     it "derives schema names from constants, instances, and defaults" do
       stub_const("NamedSchema", build_schema_class)
-      expect(NamedSchema.new.to_json_schema[:name]).to eq("NamedSchema")
+      expect(NamedSchema.new.to_ruby_llm_schema[:name]).to eq("NamedSchema")
 
-      expect(base_schema.new.to_json_schema[:name]).to eq("Schema")
-      expect(base_schema.new("CustomName").to_json_schema[:name]).to eq("CustomName")
+      expect(base_schema.new.to_ruby_llm_schema[:name]).to eq("Schema")
+      expect(base_schema.new("CustomName").to_ruby_llm_schema[:name]).to eq("CustomName")
     end
 
     it "honours description precedence" do
@@ -22,18 +22,18 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
         string :title
       end
 
-      anonymous_output = base_schema.new.to_json_schema
+      anonymous_output = base_schema.new.to_ruby_llm_schema
       expect(anonymous_output[:description]).to be_nil
 
-      class_level_output = schema_with_description.new.to_json_schema
+      class_level_output = schema_with_description.new.to_ruby_llm_schema
       expect(class_level_output[:description]).to eq("Class-level description")
 
-      instance_override = schema_with_description.new("Test", description: "Instance description").to_json_schema
+      instance_override = schema_with_description.new("Test", description: "Instance description").to_ruby_llm_schema
       expect(instance_override[:description]).to eq("Instance description")
     end
 
     it "controls additional properties and strictness" do
-      default_output = base_schema.new.to_json_schema
+      default_output = base_schema.new.to_ruby_llm_schema
       expect(default_output[:schema][:additionalProperties]).to eq(false)
       expect(default_output[:schema][:strict]).to eq(true)
 
@@ -43,7 +43,7 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
         string :title
       end
 
-      configured_output = configured_schema.new.to_json_schema
+      configured_output = configured_schema.new.to_ruby_llm_schema
       expect(configured_output[:schema][:additionalProperties]).to eq(true)
       expect(configured_output[:schema][:strict]).to eq(false)
     end
@@ -56,7 +56,7 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
         integer :count, required: false
       end
 
-      output = configured_schema.new("ConfiguredSchema").to_json_schema
+      output = configured_schema.new("ConfiguredSchema").to_ruby_llm_schema
 
       expect(output).to include(
         name: "ConfiguredSchema",
@@ -84,7 +84,7 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
       end
 
       expect(RedefinedSchema.required_properties).to eq([:name])
-      expect(RedefinedSchema.new.to_json_schema[:schema][:required]).to eq([:name])
+      expect(RedefinedSchema.new.to_ruby_llm_schema[:schema][:required]).to eq([:name])
     end
 
     it "returns nil from property declarations" do
@@ -102,7 +102,7 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
       schema_class.string :name, required: false
 
       expect(schema_class.required_properties).to eq([])
-      expect(schema_class.new.to_json_schema[:schema][:required]).to eq([])
+      expect(schema_class.new.to_ruby_llm_schema[:schema][:required]).to eq([])
     end
   end
 
@@ -131,7 +131,7 @@ RSpec.describe RubyLLM::Schema, "class inheritance approach" do
     end
 
     it "supports full-feature schemas" do
-      json_output = schema_class.new("TestSchema").to_json_schema
+      json_output = schema_class.new("TestSchema").to_ruby_llm_schema
 
       expect(json_output[:name]).to eq("TestSchema")
       expect(json_output[:schema][:additionalProperties]).to eq(true)

--- a/spec/ruby_llm/schema/entry_points/factory_spec.rb
+++ b/spec/ruby_llm/schema/entry_points/factory_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe RubyLLM::Schema, "factory method (.create) approach" do
 
     it "derives schema names from constants, instances, and defaults" do
       stub_const("NamedFactorySchema", build_factory_schema { string :title })
-      expect(NamedFactorySchema.new.to_json_schema[:name]).to eq("NamedFactorySchema")
+      expect(NamedFactorySchema.new.to_ruby_llm_schema[:name]).to eq("NamedFactorySchema")
 
-      expect(base_schema.new.to_json_schema[:name]).to eq("Schema")
-      expect(base_schema.new("CustomName").to_json_schema[:name]).to eq("CustomName")
+      expect(base_schema.new.to_ruby_llm_schema[:name]).to eq("Schema")
+      expect(base_schema.new("CustomName").to_ruby_llm_schema[:name]).to eq("CustomName")
     end
 
     it "honours description precedence" do
@@ -22,18 +22,18 @@ RSpec.describe RubyLLM::Schema, "factory method (.create) approach" do
         string :title
       end
 
-      anonymous_output = base_schema.new.to_json_schema
+      anonymous_output = base_schema.new.to_ruby_llm_schema
       expect(anonymous_output[:description]).to be_nil
 
-      class_level_output = schema_with_description.new.to_json_schema
+      class_level_output = schema_with_description.new.to_ruby_llm_schema
       expect(class_level_output[:description]).to eq("Factory description")
 
-      instance_override = schema_with_description.new("NamedSchema", description: "Instance description").to_json_schema
+      instance_override = schema_with_description.new("NamedSchema", description: "Instance description").to_ruby_llm_schema
       expect(instance_override[:description]).to eq("Instance description")
     end
 
     it "controls additional properties and strictness" do
-      default_output = base_schema.new.to_json_schema
+      default_output = base_schema.new.to_ruby_llm_schema
       expect(default_output[:schema][:additionalProperties]).to eq(false)
       expect(default_output[:schema][:strict]).to eq(true)
 
@@ -43,7 +43,7 @@ RSpec.describe RubyLLM::Schema, "factory method (.create) approach" do
         string :title
       end
 
-      configured_output = configured_schema.new.to_json_schema
+      configured_output = configured_schema.new.to_ruby_llm_schema
       expect(configured_output[:schema][:additionalProperties]).to eq(true)
       expect(configured_output[:schema][:strict]).to eq(false)
     end
@@ -56,7 +56,7 @@ RSpec.describe RubyLLM::Schema, "factory method (.create) approach" do
         integer :count, required: false
       end
 
-      output = configured_schema.new("FactoryConfiguredSchema").to_json_schema
+      output = configured_schema.new("FactoryConfiguredSchema").to_ruby_llm_schema
 
       expect(output).to include(
         name: "FactoryConfiguredSchema",
@@ -100,7 +100,7 @@ RSpec.describe RubyLLM::Schema, "factory method (.create) approach" do
     end
 
     it "supports full-feature schemas" do
-      json_output = schema_class.new("FactorySchema").to_json_schema
+      json_output = schema_class.new("FactorySchema").to_ruby_llm_schema
 
       expect(json_output[:name]).to eq("FactorySchema")
       expect(json_output[:schema][:additionalProperties]).to eq(true)

--- a/spec/ruby_llm/schema/entry_points/helpers_spec.rb
+++ b/spec/ruby_llm/schema/entry_points/helpers_spec.rb
@@ -8,20 +8,20 @@ RSpec.describe RubyLLM::Schema, "helpers module approach" do
   describe "schema attributes" do
     it "derives schema names from parameters and defaults" do
       named_schema = build_helper_schema("ProvidedName") { string :title }
-      expect(named_schema.to_json_schema[:name]).to eq("ProvidedName")
+      expect(named_schema.to_ruby_llm_schema[:name]).to eq("ProvidedName")
 
       default_schema = build_helper_schema { string :title }
-      expect(default_schema.to_json_schema[:name]).to eq("Schema")
+      expect(default_schema.to_ruby_llm_schema[:name]).to eq("Schema")
     end
 
     it "honours description precedence" do
-      default_output = build_helper_schema("TestSchema") { string :title }.to_json_schema
+      default_output = build_helper_schema("TestSchema") { string :title }.to_ruby_llm_schema
       expect(default_output[:description]).to be_nil
 
       block_description = build_helper_schema("TestSchema") do
         description "Block description"
         string :title
-      end.to_json_schema
+      end.to_ruby_llm_schema
       expect(block_description[:description]).to eq("Block description")
 
       parameter_override = build_helper_schema(
@@ -30,12 +30,12 @@ RSpec.describe RubyLLM::Schema, "helpers module approach" do
       ) do
         description "Block description"
         string :title
-      end.to_json_schema
+      end.to_ruby_llm_schema
       expect(parameter_override[:description]).to eq("Parameter description")
     end
 
     it "controls additional properties and strictness" do
-      default_output = build_helper_schema { string :title }.to_json_schema
+      default_output = build_helper_schema { string :title }.to_ruby_llm_schema
       expect(default_output[:schema][:additionalProperties]).to eq(false)
       expect(default_output[:schema][:strict]).to eq(true)
 
@@ -43,7 +43,7 @@ RSpec.describe RubyLLM::Schema, "helpers module approach" do
         additional_properties true
         strict false
         string :title
-      end.to_json_schema
+      end.to_ruby_llm_schema
 
       expect(configured_output[:schema][:additionalProperties]).to eq(true)
       expect(configured_output[:schema][:strict]).to eq(false)
@@ -57,7 +57,7 @@ RSpec.describe RubyLLM::Schema, "helpers module approach" do
         additional_properties false
         string :title
         integer :count, required: false
-      end.to_json_schema
+      end.to_ruby_llm_schema
 
       expect(json_output).to include(
         name: "HelperConfiguredSchema",
@@ -99,7 +99,7 @@ RSpec.describe RubyLLM::Schema, "helpers module approach" do
           string
           null
         end
-      end.to_json_schema
+      end.to_ruby_llm_schema
 
       expect(json_output[:name]).to eq("HelperSchema")
       expect(json_output[:description]).to eq("Comprehensive helper schema")

--- a/spec/ruby_llm/schema/json_output_spec.rb
+++ b/spec/ruby_llm/schema/json_output_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubyLLM::Schema, "JSON Schema output" do
+  let(:schema_class) do
+    Class.new(described_class) do
+      string :name
+      integer :age, required: false
+    end
+  end
+
+  describe "#to_json_schema" do
+    it "returns a Draft 2020-12 document with string keys" do
+      expect(schema_class.new("PersonSchema").to_json_schema).to eq({
+        "$schema" => "https://json-schema.org/draft/2020-12/schema",
+        "title" => "PersonSchema",
+        "type" => "object",
+        "properties" => {
+          "name" => {"type" => "string"},
+          "age" => {"type" => "integer"}
+        },
+        "required" => ["name"],
+        "additionalProperties" => false
+      })
+    end
+
+    it "omits the provider-only strict key" do
+      expect(schema_class.new.to_json_schema).not_to have_key("strict")
+    end
+
+    it "prefers an explicit title over the schema name" do
+      schema_class.title "Person"
+
+      expect(schema_class.new("PersonSchema").to_json_schema["title"]).to eq("Person")
+    end
+
+    it "prefers an instance description over the class description" do
+      schema_class.description "Class description"
+
+      document = schema_class.new("PersonSchema", description: "Instance description").to_json_schema
+
+      expect(document["description"]).to eq("Instance description")
+    end
+
+    it "stringifies definitions and references" do
+      schema_class.define :address do
+        string :street
+      end
+      schema_class.object :home, of: :address
+
+      document = schema_class.new.to_json_schema
+
+      expect(document["properties"]["home"]).to eq({"$ref" => "#/$defs/address"})
+      expect(document["$defs"]["address"]["required"]).to eq(["street"])
+    end
+
+    it "survives a JSON round trip unchanged" do
+      document = schema_class.new("PersonSchema").to_json_schema
+
+      expect(JSON.parse(JSON.generate(document))).to eq(document)
+    end
+  end
+
+  describe "#to_ruby_llm_schema" do
+    it "returns the provider envelope with symbol keys" do
+      expect(schema_class.new("PersonSchema").to_ruby_llm_schema).to eq({
+        name: "PersonSchema",
+        description: nil,
+        schema: {
+          type: "object",
+          properties: {
+            name: {type: "string"},
+            age: {type: "integer"}
+          },
+          required: [:name],
+          additionalProperties: false,
+          strict: true
+        }
+      })
+    end
+
+    it "omits strict when it is set to nil" do
+      schema_class.strict nil
+
+      expect(schema_class.new.to_ruby_llm_schema[:schema]).not_to have_key(:strict)
+    end
+  end
+
+  describe "#to_json" do
+    it "serializes the Draft 2020-12 document" do
+      expect(JSON.parse(schema_class.new("PersonSchema").to_json)).to eq(schema_class.new("PersonSchema").to_json_schema)
+    end
+  end
+end

--- a/spec/ruby_llm/schema/properties/conditionals_spec.rb
+++ b/spec/ruby_llm/schema/properties/conditionals_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RubyLLM::Schema, "conditional properties" do
   let(:schema_class) { Class.new(described_class) }
 
   def schema_output
-    schema_class.new.to_json_schema[:schema]
+    schema_class.new.to_ruby_llm_schema[:schema]
   end
 
   describe "condition coercion" do
@@ -334,7 +334,7 @@ RSpec.describe RubyLLM::Schema, "conditional properties" do
         array :addresses, of: address_schema, required: false
       end
 
-      items = parent_schema.new.to_json_schema[:schema][:properties][:addresses][:items]
+      items = parent_schema.new.to_ruby_llm_schema[:schema][:properties][:addresses][:items]
 
       expect(items[:if][:properties]["country"]).to eq({const: "US"})
       expect(items[:then][:required]).to eq(["state"])
@@ -511,7 +511,7 @@ RSpec.describe RubyLLM::Schema, "conditional properties" do
         object :payment, of: payment_schema
       end
 
-      payment = order_schema.new.to_json_schema[:schema][:properties][:payment]
+      payment = order_schema.new.to_ruby_llm_schema[:schema][:properties][:payment]
 
       expect(payment[:dependentRequired]).to eq({"credit_card" => ["billing_address"]})
     end

--- a/spec/ruby_llm/schema/properties/core_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/core_keywords_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RubyLLM::Schema, "core keywords" do
     schema_class.dynamic_ref "#node"
     schema_class.vocabulary "https://json-schema.org/draft/2020-12/vocab/core" => true
 
-    schema = schema_class.new.to_json_schema[:schema]
+    schema = schema_class.new.to_ruby_llm_schema[:schema]
 
     expect(schema).to include(
       "$id" => "https://example.com/schemas/person",

--- a/spec/ruby_llm/schema/properties/definitions_reference_spec.rb
+++ b/spec/ruby_llm/schema/properties/definitions_reference_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RubyLLM::Schema, "definitions and references" do
     expect(ref_hash).to eq({"$ref" => "#/$defs/address"})
 
     instance = schema_class.new
-    json_output = instance.to_json_schema
+    json_output = instance.to_ruby_llm_schema
 
     expect(json_output[:schema]["$defs"][:address]).to include(
       type: "object",
@@ -41,7 +41,7 @@ RSpec.describe RubyLLM::Schema, "definitions and references" do
     schema_class.object :sub_schema, of: :root
 
     instance = schema_class.new
-    json_output = instance.to_json_schema
+    json_output = instance.to_ruby_llm_schema
 
     expect(json_output[:schema][:properties][:sub_schema]).to eq({"$ref" => "#"})
   end
@@ -60,7 +60,7 @@ RSpec.describe RubyLLM::Schema, "definitions and references" do
     end
 
     instance = schema_class.new
-    json_output = instance.to_json_schema
+    json_output = instance.to_ruby_llm_schema
 
     expect(json_output[:schema][:properties][:user][:properties][:address]).to eq({"$ref" => "#/$defs/address"})
     expect(json_output[:schema]["$defs"][:address]).to eq({
@@ -86,7 +86,7 @@ RSpec.describe RubyLLM::Schema, "definitions and references" do
     end
 
     instance = schema_class.new
-    json_output = instance.to_json_schema
+    json_output = instance.to_ruby_llm_schema
 
     expect(json_output[:schema][:properties][:user][:properties][:address]).to eq({"$ref" => "#/$defs/address"})
     expect(json_output[:schema]["$defs"][:address]).to eq({
@@ -124,7 +124,7 @@ RSpec.describe RubyLLM::Schema, "definitions and references" do
 
     schema_class.object :address, of: :address
 
-    defs = schema_class.new.to_json_schema[:schema]["$defs"][:address]
+    defs = schema_class.new.to_ruby_llm_schema[:schema]["$defs"][:address]
 
     expect(defs[:if]).to eq({
       properties: {"country" => {const: "US"}},
@@ -145,7 +145,7 @@ RSpec.describe RubyLLM::Schema, "definitions and references" do
 
     schema_class.object :payment, of: :payment
 
-    defs = schema_class.new.to_json_schema[:schema]["$defs"][:payment]
+    defs = schema_class.new.to_ruby_llm_schema[:schema]["$defs"][:payment]
 
     expect(defs[:dependentRequired]).to eq({"credit_card" => ["billing_address"]})
   end
@@ -158,7 +158,7 @@ RSpec.describe RubyLLM::Schema, "definitions and references" do
 
     schema_class.object :payment, of: :payment
 
-    defs = schema_class.new.to_json_schema[:schema]["$defs"][:payment]
+    defs = schema_class.new.to_ruby_llm_schema[:schema]["$defs"][:payment]
 
     expect(defs[:dependentRequired]).to eq({"credit_card" => ["billing_address"]})
   end

--- a/spec/ruby_llm/schema/properties/metadata_annotations_spec.rb
+++ b/spec/ruby_llm/schema/properties/metadata_annotations_spec.rb
@@ -130,6 +130,6 @@ RSpec.describe RubyLLM::Schema, "metadata annotations" do
 
     expect(schema_class.title).to eq("Person")
     expect(schema_class.description).to eq("A person record")
-    expect(schema_class.new.to_json_schema[:description]).to eq("A person record")
+    expect(schema_class.new.to_json_schema["description"]).to eq("A person record")
   end
 end

--- a/spec/ruby_llm/schema/properties/nested_schemas_spec.rb
+++ b/spec/ruby_llm/schema/properties/nested_schemas_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe RubyLLM::Schema, "nested schemas" do
     end
 
     instance = schema_class.new
-    properties = instance.to_json_schema[:schema][:properties]
+    properties = instance.to_ruby_llm_schema[:schema][:properties]
 
     level3 = properties[:level1][:properties][:level2][:properties][:level3]
     expect(level3[:properties][:deep_value]).to eq({type: "string"})
@@ -130,7 +130,7 @@ RSpec.describe RubyLLM::Schema, "nested schemas" do
     stub_const("CompanySchema", company_schema)
     instance = company_schema.new("CompanySchema")
 
-    json_output = instance.to_json_schema
+    json_output = instance.to_ruby_llm_schema
     expect(json_output[:schema][:type]).to eq("object")
     expect(json_output[:schema][:properties][:employees][:items]).to eq(person_schema_hash)
     expect(json_output[:schema][:properties][:founder]).to eq(person_schema_hash)

--- a/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
+++ b/spec/ruby_llm/schema/properties/object_validation_keywords_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RubyLLM::Schema, "object validation keywords" do
       string pattern: "^[a-z_]+$"
     end
 
-    schema = schema_class.new.to_json_schema[:schema]
+    schema = schema_class.new.to_ruby_llm_schema[:schema]
 
     expect(schema[:propertyNames]).to eq({type: "string", pattern: "^[a-z_]+$"})
   end

--- a/spec/ruby_llm/schema/robustness/comprehensive_scenarios_spec.rb
+++ b/spec/ruby_llm/schema/robustness/comprehensive_scenarios_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe RubyLLM::Schema, "comprehensive scenarios" do
   include SchemaBuilders
 
   it "handles edge cases" do
-    empty_output = build_schema_class.new("EmptySchema").to_json_schema
+    empty_output = build_schema_class.new("EmptySchema").to_ruby_llm_schema
     expect(empty_output[:schema][:properties]).to eq({})
     expect(empty_output[:schema][:required]).to eq([])
 
     optional_output = build_schema_class {
       string :optional1, required: false
       integer :optional2, required: false
-    }.new.to_json_schema
+    }.new.to_ruby_llm_schema
 
     expect(optional_output[:schema][:required]).to eq([])
     expect(optional_output[:schema][:properties].keys).to contain_exactly(:optional1, :optional2)
@@ -54,7 +54,7 @@ RSpec.describe RubyLLM::Schema, "comprehensive scenarios" do
       end
 
       array :authors, of: :author
-    }.new("ComplexSchema").to_json_schema
+    }.new("ComplexSchema").to_ruby_llm_schema
 
     expect(complex_output[:schema][:properties].keys).to contain_exactly(
       :id, :metadata, :tags, :items, :status, :authors

--- a/spec/ruby_llm/schema/robustness/instance_methods_spec.rb
+++ b/spec/ruby_llm/schema/robustness/instance_methods_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe RubyLLM::Schema, "instance methods" do
 
   it "handles naming correctly" do
     stub_const("TestSchemaClass", build_schema_class)
-    expect(TestSchemaClass.new.to_json_schema[:name]).to eq("TestSchemaClass")
+    expect(TestSchemaClass.new.to_ruby_llm_schema[:name]).to eq("TestSchemaClass")
 
-    expect(schema_class.new.to_json_schema[:name]).to eq("Schema")
-    expect(schema_class.new("CustomName").to_json_schema[:name]).to eq("CustomName")
+    expect(schema_class.new.to_ruby_llm_schema[:name]).to eq("Schema")
+    expect(schema_class.new("CustomName").to_ruby_llm_schema[:name]).to eq("CustomName")
 
-    described_output = schema_class.new("TestName", description: "Custom description").to_json_schema
+    described_output = schema_class.new("TestName", description: "Custom description").to_ruby_llm_schema
     expect(described_output[:name]).to eq("TestName")
     expect(described_output[:description]).to eq("Custom description")
   end
@@ -24,7 +24,7 @@ RSpec.describe RubyLLM::Schema, "instance methods" do
       name "ConfiguredDSLName"
     end
 
-    expect(configured_schema.new.to_json_schema[:name]).to eq("ConfiguredDSLName")
+    expect(configured_schema.new.to_ruby_llm_schema[:name]).to eq("ConfiguredDSLName")
   end
 
   it "supports method delegation for schema methods" do
@@ -42,7 +42,7 @@ RSpec.describe RubyLLM::Schema, "instance methods" do
       integer :age, required: false
     end
 
-    json_output = schema_with_fields.new("TestSchema").to_json_schema
+    json_output = schema_with_fields.new("TestSchema").to_ruby_llm_schema
 
     expect(json_output).to include(
       name: "TestSchema",
@@ -61,6 +61,6 @@ RSpec.describe RubyLLM::Schema, "instance methods" do
 
     json_string = schema_with_fields.new("TestSchema").to_json
     expect(json_string).to be_a(String)
-    expect(JSON.parse(json_string)["name"]).to eq("TestSchema")
+    expect(JSON.parse(json_string)["title"]).to eq("TestSchema")
   end
 end

--- a/spec/ruby_llm/schema/robustness/runtime_values_spec.rb
+++ b/spec/ruby_llm/schema/robustness/runtime_values_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe RubyLLM::Schema, "runtime schema values" do
     first_schema = schema_class.new(user_names: %w[Alice Bob]).to_json_schema
     second_schema = schema_class.new(user_names: %w[Carol]).to_json_schema
 
-    expect(first_schema[:schema][:properties][:name][:enum]).to eq(%w[Alice Bob])
-    expect(second_schema[:schema][:properties][:name][:enum]).to eq(%w[Carol])
+    expect(first_schema.dig("properties", "name", "enum")).to eq(%w[Alice Bob])
+    expect(second_schema.dig("properties", "name", "enum")).to eq(%w[Carol])
     expect(schema_class.properties[:name][:enum]).to be_a(Proc)
   end
 
@@ -36,9 +36,9 @@ RSpec.describe RubyLLM::Schema, "runtime schema values" do
     end
 
     output = schema_class.new(user_names: %w[Alice Bob]).to_json_schema
-    name_schema = output[:schema][:properties][:users][:items][:properties][:name]
+    name_schema = output.dig("properties", "users", "items", "properties", "name")
 
-    expect(name_schema[:enum]).to eq(%w[Alice Bob])
+    expect(name_schema["enum"]).to eq(%w[Alice Bob])
   end
 
   it "supports procs that receive the schema instance" do
@@ -55,7 +55,7 @@ RSpec.describe RubyLLM::Schema, "runtime schema values" do
 
     output = schema_class.new(allowed_roles: %w[admin user]).to_json_schema
 
-    expect(output[:schema][:properties][:role][:enum]).to eq(%w[admin user])
+    expect(output.dig("properties", "role", "enum")).to eq(%w[admin user])
   end
 
   it "resolves runtime values in the description" do
@@ -68,7 +68,7 @@ RSpec.describe RubyLLM::Schema, "runtime schema values" do
       end
     end
 
-    expect(schema_class.new(audience: "admins").to_json_schema[:description]).to eq("Generated for admins")
+    expect(schema_class.new(audience: "admins").to_json_schema["description"]).to eq("Generated for admins")
   end
 
   it "serializes resolved values to JSON" do
@@ -83,6 +83,6 @@ RSpec.describe RubyLLM::Schema, "runtime schema values" do
 
     output = JSON.parse(schema_class.new(user_names: %w[Alice Bob]).to_json)
 
-    expect(output.dig("schema", "properties", "name", "enum")).to eq(%w[Alice Bob])
+    expect(output.dig("properties", "name", "enum")).to eq(%w[Alice Bob])
   end
 end

--- a/spec/ruby_llm/schema/strict_spec.rb
+++ b/spec/ruby_llm/schema/strict_spec.rb
@@ -5,25 +5,25 @@ require "spec_helper"
 RSpec.describe RubyLLM::Schema, ".strict" do
   it "outputs strict: true by default" do
     schema = Class.new(RubyLLM::Schema)
-    output = schema.new.to_json_schema
+    output = schema.new.to_ruby_llm_schema
     expect(output[:schema][:strict]).to eq(true)
   end
 
   it "omits strict from output when set to nil" do
     schema = Class.new(RubyLLM::Schema) { strict nil }
-    output = schema.new.to_json_schema
+    output = schema.new.to_ruby_llm_schema
     expect(output[:schema]).not_to have_key(:strict)
   end
 
   it "outputs strict: true when set to true" do
     schema = Class.new(RubyLLM::Schema) { strict true }
-    output = schema.new.to_json_schema
+    output = schema.new.to_ruby_llm_schema
     expect(output[:schema][:strict]).to eq(true)
   end
 
   it "outputs strict: false when set to false" do
     schema = Class.new(RubyLLM::Schema) { strict false }
-    output = schema.new.to_json_schema
+    output = schema.new.to_ruby_llm_schema
     expect(output[:schema][:strict]).to eq(false)
   end
 end


### PR DESCRIPTION
Closes #32

## Summary
- Make `to_json_schema` return a pure Draft 2020-12 JSON Schema document
- Add `to_json_schema_document` as an alias for the pure output
- Keep the old RubyLLM/provider envelope available as `to_ruby_llm_schema`
- Map schema names to JSON Schema `title` when no explicit root title exists
- Omit provider-only `strict` from pure output and stringify keys for JSON compatibility
- Document the migration path

## Verification
- `bundle exec rake`