### PR TITLE
Add const validation keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ end
 String types support the following properties:
 
 - `enum`: an array of allowed values (e.g. `enum: ["on", "off"]`)
+- `const`: the single allowed value (e.g. `const: "admin"`)
 - `pattern`: a regex pattern (e.g. `pattern: "\\d+"`)
 - `format`: a format string (e.g. `format: "email"`)
 - `min_length`: the minimum length of the string (e.g. `min_length: 3`)
@@ -236,6 +237,7 @@ string :name, description: "Person's full name"
 string :email, format: "email"
 string :phone, pattern: "\\d+"
 string :status, enum: ["on", "off"]
+string :role, const: "admin"
 string :code, min_length: 3, max_length: 10
 ```
 
@@ -244,6 +246,7 @@ string :code, min_length: 3, max_length: 10
 Number and integer types support the following properties:
 
 - `enum`: an array of allowed numeric values (e.g. `enum: [0, 1, 2]`)
+- `const`: the single allowed value (e.g. `const: 1`)
 - `multiple_of`: a multiple of the number (e.g. `multiple_of: 0.01`)
 - `minimum`: the minimum value of the number (e.g. `minimum: 0`)
 - `maximum`: the maximum value of the number (e.g. `maximum: 100`)
@@ -261,9 +264,10 @@ integer :level, enum: [0, 1, 2]
 
 ```ruby
 boolean :is_active
+boolean :accepted_terms, const: true
 ```
 
-Boolean types doesn't support any additional properties.
+Boolean types only support `const`, the single allowed value.
 
 ### Null
 

--- a/lib/ruby_llm/schema/dsl/schema_builders.rb
+++ b/lib/ruby_llm/schema/dsl/schema_builders.rb
@@ -4,10 +4,11 @@ module RubyLLM
   class Schema
     module DSL
       module SchemaBuilders
-        def string_schema(description: nil, enum: nil, min_length: nil, max_length: nil, pattern: nil, format: nil)
+        def string_schema(description: nil, enum: nil, const: nil, min_length: nil, max_length: nil, pattern: nil, format: nil)
           {
             type: "string",
             enum: enum,
+            const: const,
             description: description,
             minLength: min_length,
             maxLength: max_length,
@@ -16,7 +17,7 @@ module RubyLLM
           }.compact
         end
 
-        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil, enum: nil)
+        def number_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil, enum: nil, const: nil)
           {
             type: "number",
             description: description,
@@ -25,11 +26,12 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of,
-            enum: enum
+            enum: enum,
+            const: const
           }.compact
         end
 
-        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil, enum: nil)
+        def integer_schema(description: nil, minimum: nil, maximum: nil, greater_than: nil, less_than: nil, multiple_of: nil, enum: nil, const: nil)
           {
             type: "integer",
             description: description,
@@ -38,12 +40,13 @@ module RubyLLM
             exclusiveMinimum: greater_than,
             exclusiveMaximum: less_than,
             multipleOf: multiple_of,
-            enum: enum
+            enum: enum,
+            const: const
           }.compact
         end
 
-        def boolean_schema(description: nil)
-          {type: "boolean", description: description}.compact
+        def boolean_schema(description: nil, const: nil)
+          {type: "boolean", description: description, const: const}.compact
         end
 
         def null_schema(description: nil)

--- a/spec/ruby_llm/schema/properties/booleans_spec.rb
+++ b/spec/ruby_llm/schema/properties/booleans_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe RubyLLM::Schema, "boolean properties" do
     properties = schema_class.properties
     expect(properties[:enabled]).to eq({type: "boolean", description: "Enabled field"})
   end
+
+  it "supports boolean const values" do
+    schema_class.boolean :enabled, const: false
+
+    properties = schema_class.properties
+    expect(properties[:enabled]).to eq({type: "boolean", const: false})
+  end
 end

--- a/spec/ruby_llm/schema/properties/numbers_spec.rb
+++ b/spec/ruby_llm/schema/properties/numbers_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
     expect(properties[:score]).to eq({type: "number", enum: [0.5, 1.5]})
   end
 
+  it "supports number const values" do
+    schema_class.number :version, const: 1.5
+
+    properties = schema_class.properties
+    expect(properties[:version]).to eq({type: "number", const: 1.5})
+  end
+
   it "supports exclusive number boundaries" do
     schema_class.number :score, greater_than: 0, less_than: 100
 
@@ -48,6 +55,13 @@ RSpec.describe RubyLLM::Schema, "numeric properties" do
 
     properties = schema_class.properties
     expect(properties[:count]).to eq({type: "integer", description: "Count value"})
+  end
+
+  it "supports integer const values" do
+    schema_class.integer :version, const: 1
+
+    properties = schema_class.properties
+    expect(properties[:version]).to eq({type: "integer", const: 1})
   end
 
   it "supports exclusive integer boundaries" do

--- a/spec/ruby_llm/schema/properties/strings_spec.rb
+++ b/spec/ruby_llm/schema/properties/strings_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe RubyLLM::Schema, "string properties" do
     })
   end
 
+  it "supports string const values" do
+    schema_class.string :role, const: "admin"
+
+    properties = schema_class.properties
+    expect(properties[:role]).to eq({type: "string", const: "admin"})
+  end
+
   it "supports string type with additional options" do
     schema_class.string :email, format: "email", min_length: 5, max_length: 100, pattern: "\\S+@\\S+", description: "Email field"
 


### PR DESCRIPTION
Closes #34

Supersedes #46, which GitHub closed when its base branch was deleted.

## Summary
- Add `const:` to string, number, integer, and boolean schemas
- Document `const` in the README

## Verification
- `bundle exec rake`